### PR TITLE
Refactor artifact controller methods to ensure async operations are a…

### DIFF
--- a/Frontend/vta_app/lib/src/controllers/artifact_controller.dart
+++ b/Frontend/vta_app/lib/src/controllers/artifact_controller.dart
@@ -107,11 +107,11 @@ class ArtefactController extends ChangeNotifier {
     }
   }
 
-  Future<void> newArtifact(BuildContext context, String categoryId) async {
+Future<void> newArtifact(BuildContext context, String categoryId) async {
     var popup = AddItemPopup(
         isCategory: false,
         title: 'Tilføj artefakt',
-        onSubmit: (name, imageBytes, soundBytes) {
+        onSubmit: (name, imageBytes, soundBytes) async {
           try {
             var newArtefact = Artefact(
                 categoryId: categoryId,
@@ -120,9 +120,11 @@ class ArtefactController extends ChangeNotifier {
                 image: imageBytes,
                 sound: soundBytes,
                 name: name);
-            _model.postArtefact(newArtefact,
+            await _model.postArtefact(newArtefact,
                 token: GetIt.I.get<Token>().value!);
-            _showSuccessActionSnackBar(context, 'Artefact tilføjet');
+              if (context.mounted) {
+                _showSuccessActionSnackBar(context, 'Artefact tilføjet');
+              }
             notifyListeners();
           } catch (e) {
             if (context.mounted) {
@@ -138,15 +140,15 @@ class ArtefactController extends ChangeNotifier {
         });
   }
 
-  Future<void> deleteArtefact(BuildContext context, Artefact artefact) async {
+Future<void> deleteArtefact(BuildContext context, Artefact artefact) async {
     // Save ScaffoldMessenger reference before dialog
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     final screenHeight = MediaQuery.of(context).size.height;
 
     try {
       await _showDeleteConfirmationDialog(context, onDelete: () async {
-        _model.deleteArtefact(artefact, token: GetIt.I.get<Token>().value!);
-
+        await _model.deleteArtefact(artefact, token: GetIt.I.get<Token>().value!);
+        notifyListeners();
         _showSuccessSnackBarAfterAsync(
           scaffoldMessenger,
           screenHeight,

--- a/Frontend/vta_app/lib/src/ui/widgets/categories/categories_widget.dart
+++ b/Frontend/vta_app/lib/src/ui/widgets/categories/categories_widget.dart
@@ -288,10 +288,15 @@ class _CategoriesWidgetState extends State<CategoriesWidget> {
         builder: (BuildContext context) {
           return Padding(
             padding: const EdgeInsets.only(top: 10),
-            child: FractionallySizedBox(
-              heightFactor: 0.8,
-              child: _buildImageGrid(category),
-            ),
+                          child: ListenableBuilder(
+                listenable: widget.artefactController,
+                builder: (context, child) {
+                  // Find the updated category from the controller
+                  Category? updatedCategory = widget.artefactController.categories
+                      ?.firstWhere((cat) => cat.categoryId == category.categoryId);
+                  return _buildImageGrid(updatedCategory ?? category);
+                },
+              ),
           );
         },
       );

--- a/Frontend/vta_app/lib/src/ui/widgets/categories/categories_widget.dart
+++ b/Frontend/vta_app/lib/src/ui/widgets/categories/categories_widget.dart
@@ -299,15 +299,7 @@ class _CategoriesWidgetState extends State<CategoriesWidget> {
   }
 
 // ModalSheet for editing and deleting categories
-  void _showCategoryEditModal(BuildContext context, Category category) {
-    final categoriesEdit = CategoriesEdit(
-      categoryName: category.name!,
-      imageUrl: category.imageUrl,
-      categoryId: category.categoryId!,
-      onEdit: () {
-        MaterialPageRoute(builder: (context) => AddPicturePage());
-      }, // Pass edit functionality if needed
-    );
+void _showCategoryEditModal(BuildContext context, Category category) {
     showModalBottomSheet(
       backgroundColor: Colors.white,
       isScrollControlled: true,
@@ -429,8 +421,6 @@ class _CategoriesWidgetState extends State<CategoriesWidget> {
   Widget _buildImageGridItem(BuildContext context, int index, Category category,
       bool isInDeletionMode, VoidCallback onLongPress,
       {required VoidCallback onDelete}) {
-    var authState = Provider.of<AuthState>(context);
-    var artifactState = Provider.of<ArtifactState>(context, listen: false);
     var headers = <String, String>{
       'Authorization': 'Bearer ${GetIt.instance.get<Token>().value}'
     };


### PR DESCRIPTION
This pull request introduces improvements to the artefact management workflow and refactors some UI components to simplify category editing and image grid item handling. The main changes focus on ensuring proper state updates after artefact modifications and cleaning up unused code in the category widgets.

**Artefact management improvements:**

* The `onSubmit` callback in the artefact addition popup is now asynchronous, ensuring that artefact creation completes before proceeding. Success feedback is only shown if the context is still mounted. [[1]](diffhunk://#diff-7259ab8abd8d91b32069c58d9a4a646d540fa87b17f29a742d500200cc0f114aL114-R114) [[2]](diffhunk://#diff-7259ab8abd8d91b32069c58d9a4a646d540fa87b17f29a742d500200cc0f114aL123-R127)
* The artefact deletion logic now awaits the deletion operation and calls `notifyListeners()` to update the UI after the artefact is removed.

**UI and code cleanup:**

* Removed the unused `CategoriesEdit` instantiation and related code from the category edit modal, streamlining the modal sheet logic.
* Cleaned up the image grid item builder by removing unnecessary `Provider` calls for `AuthState` and `ArtifactState`, reducing widget complexity.…waited and improve context checks in newArtifact and deleteArtefact methods. Clean up category edit modal implementation in CategoriesWidget.

# Description

*Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.*

Fixes #181 