### PR TITLE
fix: Correct method name typo SingUp to SignUp

### DIFF
--- a/Backend/VTA.API/Controllers/UsersController.cs
+++ b/Backend/VTA.API/Controllers/UsersController.cs
@@ -68,7 +68,7 @@ public class UsersController(VTAContext context, IConfiguration config) : Contro
     [AllowAnonymous]//Allows a user to not have a JWT
     [Route("SignUp")] // = api/Users/SignUp
     [HttpPost]
-    public async Task<ActionResult<UserLoginResponseDTO>> SingUp(UserSignupDTO userSignUp)
+    public async Task<ActionResult<UserLoginResponseDTO>> SignUp(UserSignupDTO userSignUp)
     {
         if (userSignUp == null)
         {


### PR DESCRIPTION
## Summary
- Fixes typo in method name: `SingUp` → `SignUp` in UsersController.cs
- Cosmetic change only - the route attribute already used the correct spelling "SignUp"
- No functional changes

## Test plan
- [x] Build passes
- [x] All 98 existing tests pass