### PR TITLE
fix: Centralize magic strings in Constants.cs

### DIFF
--- a/Backend/VTA.API/Constants.cs
+++ b/Backend/VTA.API/Constants.cs
@@ -1,0 +1,32 @@
+namespace VTA.API;
+
+/// <summary>
+/// Centralized constants used throughout the VTA API.
+/// </summary>
+public static class Constants
+{
+    /// <summary>
+    /// Default board name created for new users during signup.
+    /// </summary>
+    public const string DefaultBoardName = "Board1";
+
+    /// <summary>
+    /// Category identifier for session-scoped artefacts that are cleaned up when a board is cleared.
+    /// </summary>
+    public const string SessionArtefactCategory = "Session-Artefact";
+
+    /// <summary>
+    /// Prefix added to image filenames for clarity in the filesystem.
+    /// </summary>
+    public const string ImageFilePrefix = "image_";
+
+    /// <summary>
+    /// Directory names for asset storage.
+    /// </summary>
+    public static class AssetDirectories
+    {
+        public const string Artefacts = "Artefacts";
+        public const string Categories = "Categories";
+        public const string Sounds = "Sounds";
+    }
+}

--- a/Backend/VTA.API/Controllers/SavedArtefactsController.cs
+++ b/Backend/VTA.API/Controllers/SavedArtefactsController.cs
@@ -193,11 +193,11 @@ public class SavedArtefactsController : ControllerBase
         _context.SavedArtefacts.RemoveRange(board.SavedArtefacts);
       }
 
-      // Also delete any session artefacts (category == 'Session-Artefact') that belong to this user
+      // Also delete any session artefacts that belong to this user
       if (artefactIdsOnBoard.Any())
       {
         var sessionArtefacts = await _context.Artefacts
-            .Where(a => artefactIdsOnBoard.Contains(a.ArtefactId) && a.UserId == userId && a.CategoryId == "Session-Artefact")
+            .Where(a => artefactIdsOnBoard.Contains(a.ArtefactId) && a.UserId == userId && a.CategoryId == Constants.SessionArtefactCategory)
             .ToListAsync();
 
         if (sessionArtefacts != null && sessionArtefacts.Any())

--- a/Backend/VTA.API/Controllers/UsersController.cs
+++ b/Backend/VTA.API/Controllers/UsersController.cs
@@ -92,7 +92,7 @@ public class UsersController(VTAContext context, IConfiguration config) : Contro
         var defaultBoard = new SavedBoard
         {
             Id = Guid.NewGuid().ToString(),
-            Name = "Board1",
+            Name = Constants.DefaultBoardName,
             UserId = user.Id,
             CreatedDate = DateTime.UtcNow
         };

--- a/Backend/VTA.API/Program.cs
+++ b/Backend/VTA.API/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.OpenApi.Models;
 using System.IdentityModel.Tokens.Jwt;
 using System.Reflection;
 using System.Text;
+using VTA.API;
 using VTA.API.Extensions;
 using VTA.API.Utilities;
 using VTA.Data.Extensions;
@@ -103,17 +104,17 @@ if (!Directory.Exists(assetsDirs))
 {
     Directory.CreateDirectory(assetsDirs);
 }
-assetsDirs = Path.Combine(Directory.GetCurrentDirectory(), "Assets", "Categories");
+assetsDirs = Path.Combine(Directory.GetCurrentDirectory(), "Assets", Constants.AssetDirectories.Categories);
 if (!Directory.Exists(assetsDirs))
 {
     Directory.CreateDirectory(assetsDirs);
 }
-assetsDirs = Path.Combine(Directory.GetCurrentDirectory(), "Assets", "Artefacts");
+assetsDirs = Path.Combine(Directory.GetCurrentDirectory(), "Assets", Constants.AssetDirectories.Artefacts);
 if (!Directory.Exists(assetsDirs))
 {
     Directory.CreateDirectory(assetsDirs);
 }
-assetsDirs = Path.Combine(Directory.GetCurrentDirectory(), "Assets", "Sounds");
+assetsDirs = Path.Combine(Directory.GetCurrentDirectory(), "Assets", Constants.AssetDirectories.Sounds);
 if (!Directory.Exists(assetsDirs))
 {
     Directory.CreateDirectory(assetsDirs);

--- a/Backend/VTA.API/Utilities/ImageUtilities.cs
+++ b/Backend/VTA.API/Utilities/ImageUtilities.cs
@@ -22,8 +22,8 @@ public static class ImageUtilities
         string _APIEndpoint = "/api/Assets/" + _Dir + "/";
         if (image != null && image.Length > 0)
         {
-            // Add "image_" prefix to filename for clarity
-            string fileName = "image_" + artefactId + Path.GetExtension(image.FileName);
+            // Add image prefix to filename for clarity
+            string fileName = Constants.ImageFilePrefix + artefactId + Path.GetExtension(image.FileName);
             // Create user-specific folder structure: Assets/{dir}/{userId}/
             string imageFolder = Path.Combine(BaseAssetsPath, _Dir, userId);
 
@@ -83,9 +83,9 @@ public static class ImageUtilities
                 return null;
             }
 
-            // Look for files with "image_" prefix
+            // Look for files with image prefix
             var tempfile = Directory.EnumerateFiles(path)
-                        .FirstOrDefault(f => Path.GetFileNameWithoutExtension(f).Equals("image_" + fileName, StringComparison.OrdinalIgnoreCase));
+                        .FirstOrDefault(f => Path.GetFileNameWithoutExtension(f).Equals(Constants.ImageFilePrefix + fileName, StringComparison.OrdinalIgnoreCase));
 
             file = tempfile?.Replace(path, "").Remove(0, 1);
         }

--- a/Backend/VTA.Tests/IntegrationTests/ControllerTests/BoardsControllerTests.cs
+++ b/Backend/VTA.Tests/IntegrationTests/ControllerTests/BoardsControllerTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using VTA.API;
 using VTA.API.DTOs;
 using VTA.Tests.TestHelpers;
 
@@ -35,7 +36,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
     var boards = await response.Content.ReadFromJsonAsync<List<BoardGetDTO>>();
     Assert.NotNull(boards);
     Assert.Single(boards);
-    Assert.Equal("Board1", boards[0].Name);  // Verify default board exists
+    Assert.Equal(Constants.DefaultBoardName, boards[0].Name);  // Verify default board exists
 
     await _utilities.DeleteUserAsync(loginData.userId, loginData.Token);
   }
@@ -48,7 +49,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
     Assert.Equal(HttpStatusCode.OK, signUpStatus);
     Assert.NotNull(loginData);
 
-    // Create additional boards (default "Board1" already exists)
+    // Create additional boards (default board already exists)
     var board2 = await CreateTestBoard(loginData, "Board 2");
     var board3 = await CreateTestBoard(loginData, "Board 3");
 
@@ -93,7 +94,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
     var boardList = await response.Content.ReadFromJsonAsync<List<BoardListItemDTO>>();
     Assert.NotNull(boardList);
     Assert.Equal(2, boardList.Count);
-    Assert.Contains(boardList, b => b.Name == "Board1");  // Verify default board
+    Assert.Contains(boardList, b => b.Name == Constants.DefaultBoardName);  // Verify default board
     Assert.Contains(boardList, b => b.Name == "Test Board");  // Verify created board
 
     await _utilities.DeleteUserAsync(loginData.userId, loginData.Token);


### PR DESCRIPTION
## Summary
- Introduces `Constants.cs` to centralize magic strings used across the backend
- Replaces hardcoded strings for default board name, session artefact category, and asset directories
- Improves maintainability by having a single source of truth for these values

**Constants introduced:**
- `Constants.DefaultBoardName` ("Board1")
- `Constants.SessionArtefactCategory` ("Session-Artefact")
- `Constants.ImageFilePrefix` ("image_")
- `Constants.AssetDirectories.Artefacts`, `.Categories`, `.Sounds`

## Test plan
- [x] Build passes
- [x] All 98 existing tests pass
- [x] Tests updated to use constants for assertions