### PR TITLE
fix: Return 201 Created from SignUp endpoint

### DIFF
--- a/Backend/VTA.API/Controllers/UsersController.cs
+++ b/Backend/VTA.API/Controllers/UsersController.cs
@@ -115,21 +115,17 @@ public class UsersController(VTAContext context, IConfiguration config) : Contro
             }
         }
 
-        return await AutoSignIn(user);
+        var loginResponse = GenerateLoginResponse(user);
+        return CreatedAtAction(nameof(GetUser), new { id = user.Id }, loginResponse);
     }
 
     /// <summary>
-    /// Requested by the front-end. The intended functionality is pretty clear.
+    /// Generates a login response DTO for a user.
     /// </summary>
-    /// <remarks>
-    /// See <see cref="UsersController.SignUp"/>Refer to the SignUp method for user registration details.
-    /// See <see cref="VTA.API.DTOs.UserLoginResponseDTO"/>Refer to the UserLoginResponseDTO for details on the login response format.
-    /// </remarks>
-    /// <param name="user">The user that was just created in SignUp.</param>
-    /// <returns>A Login object containing authentication details.</returns>
-    private async Task<ActionResult<UserLoginResponseDTO>> AutoSignIn(User user)
+    /// <param name="user">The user to generate a login response for.</param>
+    /// <returns>A UserLoginResponseDTO containing the JWT token and user ID.</returns>
+    private UserLoginResponseDTO GenerateLoginResponse(User user)
     {
-        var userGetDTO = DTOConverter.MapUserToUserGetDTO(user);
         var token = GenerateJwt(user);
         return new UserLoginResponseDTO
         {

--- a/Backend/VTA.Tests/IntegrationTests/ControllerTests/ArtefactsControllerTests.cs
+++ b/Backend/VTA.Tests/IntegrationTests/ControllerTests/ArtefactsControllerTests.cs
@@ -25,7 +25,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData); // Ensure we have valid login data
 
         var content = new MultipartFormDataContent();
@@ -98,7 +98,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
         // Arrange: Create a test user
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         // Arrange: Prepare test image data
@@ -176,8 +176,8 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
         var (signUpStatus1, loginData1) = await _utilities.SignUpUserAsync(username1, "testpassword1", "Test User 1");
         var (signUpStatus2, loginData2) = await _utilities.SignUpUserAsync(username2, "testpassword2", "Test User 2");
 
-        Assert.Equal(HttpStatusCode.OK, signUpStatus1);
-        Assert.Equal(HttpStatusCode.OK, signUpStatus2);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus1);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus2);
         Assert.NotNull(loginData1);
         Assert.NotNull(loginData2);
 
@@ -266,7 +266,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         // Add two test artefacts
@@ -303,7 +303,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         // Create a test artefact
@@ -359,7 +359,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         // Create a test artefact
@@ -388,7 +388,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var content = new MultipartFormDataContent
@@ -415,7 +415,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var imageContent = new ByteArrayContent(await File.ReadAllBytesAsync("IntegrationTests/TestData/testImage"));
@@ -445,7 +445,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/api/Users/Artefacts/non-existent-id");
@@ -462,7 +462,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var content = new MultipartFormDataContent
@@ -490,7 +490,7 @@ public class ArtefactsControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var request = new HttpRequestMessage(HttpMethod.Delete, "/api/Users/Artefacts/non-existent-id");

--- a/Backend/VTA.Tests/IntegrationTests/ControllerTests/BoardsControllerTests.cs
+++ b/Backend/VTA.Tests/IntegrationTests/ControllerTests/BoardsControllerTests.cs
@@ -23,7 +23,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     var request = new HttpRequestMessage(HttpMethod.Get, "/api/Users/Boards");
@@ -45,7 +45,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     // Create additional boards (default "Board1" already exists)
@@ -79,7 +79,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     var board = await CreateTestBoard(loginData, "Test Board");
@@ -112,7 +112,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     var createdBoard = await CreateTestBoard(loginData, "Test Board");
@@ -137,7 +137,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     var request = new HttpRequestMessage(HttpMethod.Get, "/api/Users/Boards/non-existent-id");
@@ -154,11 +154,11 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username1 = _utilities.GenerateUniqueUsername();
     var (signUpStatus1, loginData1) = await _utilities.SignUpUserAsync(username1, "password1", "User One");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus1);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus1);
 
     var username2 = _utilities.GenerateUniqueUsername();
     var (signUpStatus2, loginData2) = await _utilities.SignUpUserAsync(username2, "password2", "User Two");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus2);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus2);
 
     var board = await CreateTestBoard(loginData1!, "User 1 Board");
 
@@ -186,7 +186,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     var boardPostDTO = new BoardPostDTO
@@ -235,7 +235,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     var board = await CreateTestBoard(loginData, "Original Name");
@@ -273,7 +273,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     var boardPatchDTO = new BoardPatchDTO
@@ -317,7 +317,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     var board = await CreateTestBoard(loginData, "Board to Delete");
@@ -342,7 +342,7 @@ public class BoardsControllerTests : IClassFixture<CustomApplicationFactory>
   {
     var username = _utilities.GenerateUniqueUsername();
     var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-    Assert.Equal(HttpStatusCode.OK, signUpStatus);
+    Assert.Equal(HttpStatusCode.Created, signUpStatus);
     Assert.NotNull(loginData);
 
     var request = new HttpRequestMessage(HttpMethod.Delete, "/api/Users/Boards/non-existent-id");

--- a/Backend/VTA.Tests/IntegrationTests/ControllerTests/CategoriesControllerTests.cs
+++ b/Backend/VTA.Tests/IntegrationTests/ControllerTests/CategoriesControllerTests.cs
@@ -24,7 +24,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         var token = signUpResult?.Token;
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/api/Users/Categories");
@@ -44,7 +44,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         var token = signUpResult?.Token;
         var userId = signUpResult?.userId;
 
@@ -77,7 +77,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         var token = signUpResult?.Token;
         var userId = signUpResult?.userId;
 
@@ -119,7 +119,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         var token = signUpResult?.Token;
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/api/Users/Categories/nonexistent");
@@ -139,7 +139,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         var token = signUpResult?.Token;
         var userId = signUpResult?.userId;
 
@@ -197,7 +197,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         var token = signUpResult?.Token;
 
         var patchDTO = new CategoryPatchDTO
@@ -225,13 +225,13 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username1 = _utilities.GenerateUniqueUsername();
         var (signUpStatus1, signUpResult1) = await _utilities.SignUpUserAsync(username1, "password1", "User One");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus1);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus1);
         var token1 = signUpResult1?.Token;
         var userId1 = signUpResult1?.userId;
 
         var username2 = _utilities.GenerateUniqueUsername();
         var (signUpStatus2, signUpResult2) = await _utilities.SignUpUserAsync(username2, "password2", "User Two");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus2);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus2);
         var token2 = signUpResult2?.Token;
 
         var categoryPostDTO = new CategoryPostDTO
@@ -268,7 +268,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         // Create a test category
@@ -299,7 +299,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var category = await CreateTestCategory(loginData, "Test Category");
@@ -330,7 +330,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var category = await CreateTestCategory(loginData, "Test Category");
@@ -373,7 +373,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/api/Users/Categories/non-existent-id/usage");
@@ -390,11 +390,11 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username1 = _utilities.GenerateUniqueUsername();
         var (signUpStatus1, loginData1) = await _utilities.SignUpUserAsync(username1, "password1", "User One");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus1);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus1);
 
         var username2 = _utilities.GenerateUniqueUsername();
         var (signUpStatus2, loginData2) = await _utilities.SignUpUserAsync(username2, "password2", "User Two");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus2);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus2);
 
         var category = await CreateTestCategory(loginData1!, "User 1 Category");
 
@@ -422,7 +422,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         // Create multiple categories with different usage counts
@@ -454,7 +454,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         // Create categories with specific usage patterns
@@ -493,7 +493,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         // Create 5 categories
@@ -526,7 +526,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/api/Users/Categories/most-used");
@@ -547,7 +547,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         // Create categories with same usage count but different last used dates
@@ -585,11 +585,11 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username1 = _utilities.GenerateUniqueUsername();
         var (signUpStatus1, loginData1) = await _utilities.SignUpUserAsync(username1, "password1", "User One");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus1);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus1);
 
         var username2 = _utilities.GenerateUniqueUsername();
         var (signUpStatus2, loginData2) = await _utilities.SignUpUserAsync(username2, "password2", "User Two");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus2);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus2);
 
         // Create categories for both users
         var user1Category = await CreateTestCategory(loginData1!, "User 1 Category");
@@ -628,7 +628,7 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
     {
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var category = await CreateTestCategory(loginData, "Category With Artefacts");

--- a/Backend/VTA.Tests/IntegrationTests/ControllerTests/SavedBoardArtefactsAdvancedTests.cs
+++ b/Backend/VTA.Tests/IntegrationTests/ControllerTests/SavedBoardArtefactsAdvancedTests.cs
@@ -34,7 +34,7 @@ public class SavedBoardArtefactsAdvancedTests : IClassFixture<CustomApplicationF
         // Arrange: Create user and multiple artefacts
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Performance Tester");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -100,7 +100,7 @@ public class SavedBoardArtefactsAdvancedTests : IClassFixture<CustomApplicationF
         // Arrange: Create board with multiple instances of same artefact
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Concurrency Tester");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -178,7 +178,7 @@ public class SavedBoardArtefactsAdvancedTests : IClassFixture<CustomApplicationF
         // Arrange: Test with extreme float values
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Extreme Values Tester");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -227,7 +227,7 @@ public class SavedBoardArtefactsAdvancedTests : IClassFixture<CustomApplicationF
         // Arrange: Complete lifecycle test
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Lifecycle Tester");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -340,7 +340,7 @@ public class SavedBoardArtefactsAdvancedTests : IClassFixture<CustomApplicationF
         // Arrange: Create multiple boards
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Multi Board Tester");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;

--- a/Backend/VTA.Tests/IntegrationTests/ControllerTests/SavedBoardArtefactsTests.cs
+++ b/Backend/VTA.Tests/IntegrationTests/ControllerTests/SavedBoardArtefactsTests.cs
@@ -34,7 +34,7 @@ public class SavedBoardArtefactsTests : IClassFixture<CustomApplicationFactory>
         // Arrange: Create user and login
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Board Creator");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -94,7 +94,7 @@ public class SavedBoardArtefactsTests : IClassFixture<CustomApplicationFactory>
         // Arrange: Create user and one artefact
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Duplicate Tester");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -142,7 +142,7 @@ public class SavedBoardArtefactsTests : IClassFixture<CustomApplicationFactory>
         // Arrange: Create board with duplicate artefacts
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Position Updater");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -213,7 +213,7 @@ public class SavedBoardArtefactsTests : IClassFixture<CustomApplicationFactory>
         // Arrange: Create board with multiple instances
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Delete Tester");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -268,7 +268,7 @@ public class SavedBoardArtefactsTests : IClassFixture<CustomApplicationFactory>
         // Arrange
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Error Tester");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -296,7 +296,7 @@ public class SavedBoardArtefactsTests : IClassFixture<CustomApplicationFactory>
         // Arrange: Create board with artefacts
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Data Verifier");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;
@@ -343,7 +343,7 @@ public class SavedBoardArtefactsTests : IClassFixture<CustomApplicationFactory>
         // Arrange: Create board with artefacts
         var username = _utilities.GenerateUniqueUsername();
         var (signUpStatus, loginData) = await _utilities.SignUpUserAsync(username, "testpassword", "Board Deleter");
-        Assert.Equal(HttpStatusCode.OK, signUpStatus);
+        Assert.Equal(HttpStatusCode.Created, signUpStatus);
         Assert.NotNull(loginData);
 
         var token = loginData!.Token;

--- a/Backend/VTA.Tests/IntegrationTests/ControllerTests/UsersControllerTests.cs
+++ b/Backend/VTA.Tests/IntegrationTests/ControllerTests/UsersControllerTests.cs
@@ -23,8 +23,7 @@ namespace VTA.Tests.IntegrationTests.ControllerTests
             var username = _utilities.GenerateUniqueUsername();
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
 
-            // TODO: Signup endpoint should actually return 201 (for creation) instead of 200 (for read, update and delete)
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var deleteStatus = await _utilities.DeleteUserAsync(signUpResult!.userId, signUpResult.Token);
@@ -35,9 +34,8 @@ namespace VTA.Tests.IntegrationTests.ControllerTests
         public async Task TestUserLogin()
         {
             var username = _utilities.GenerateUniqueUsername();
-            // TODO: Signup endpoint should actually return 201 (for creation) instead of 200 (for read, update and delete)
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var (loginStatus, loginResult) = await _utilities.LoginUserAsync(username, "testpassword");
@@ -53,9 +51,8 @@ namespace VTA.Tests.IntegrationTests.ControllerTests
         public async Task TestUserDeletion()
         {
             var username = _utilities.GenerateUniqueUsername();
-            // TODO: Signup endpoint should actually return 201 (for creation) instead of 200 (for read, update and delete)
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var (loginStatus, loginResult) = await _utilities.LoginUserAsync(username, "testpassword");
@@ -92,9 +89,8 @@ namespace VTA.Tests.IntegrationTests.ControllerTests
         public async Task TestLoginWithIncorrectPasswordReturnsNotFound()
         {
             var username = _utilities.GenerateUniqueUsername();
-            // TODO: Signup endpoint should actually return 201 (for creation) instead of 200 (for read, update and delete)
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "correctpassword", "Test User");
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var (loginStatus, loginResult) = await _utilities.LoginUserAsync("testuser", "wrongpassword");
@@ -139,9 +135,9 @@ namespace VTA.Tests.IntegrationTests.ControllerTests
             var (signUpStatus2, signUpResult2) = await _utilities.SignUpUserAsync(username2, "password2", "User Two");
 
             // Assert - Ensure both users signed up successfully
-            Assert.Equal(HttpStatusCode.OK, signUpStatus1);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus1);
             Assert.NotNull(signUpResult1?.Token);
-            Assert.Equal(HttpStatusCode.OK, signUpStatus2);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus2);
             Assert.NotNull(signUpResult2?.Token);
 
             // Act - Unauthorized delete attempt

--- a/Backend/VTA.Tests/TestHelpers/Utilities.cs
+++ b/Backend/VTA.Tests/TestHelpers/Utilities.cs
@@ -63,11 +63,10 @@ namespace VTA.Tests.TestHelpers
             return response.StatusCode;
         }
 
-        // TODO: Signup endpoint should actually return 201 (for creation) instead of 200 (for read, update and delete)
         public async Task<string?> CreateUserAndReturnTokenAsync()
         {
             var (signUpStatus, signUpResult) = await SignUpUserAsync(DefaultUsername, DefaultPassword, DefaultName);
-            if (signUpStatus == HttpStatusCode.OK && signUpResult != null)
+            if (signUpStatus == HttpStatusCode.Created && signUpResult != null)
             {
                 return signUpResult.Token;
             }
@@ -77,7 +76,7 @@ namespace VTA.Tests.TestHelpers
         public async Task<UserLoginResponseDTO?> CreateUserAndReturnLoginDataAsync()
         {
             var (signUpStatus, signUpResult) = await SignUpUserAsync(DefaultUsername, DefaultPassword, DefaultName);
-            if (signUpStatus == HttpStatusCode.OK && signUpResult != null)
+            if (signUpStatus == HttpStatusCode.Created && signUpResult != null)
             {
                 return signUpResult;
             }

--- a/Backend/VTA.Tests/UnitTests/CategoryServiceTests.cs
+++ b/Backend/VTA.Tests/UnitTests/CategoryServiceTests.cs
@@ -24,7 +24,7 @@ namespace VTA.Tests.UnitTests
             var username = _utilities.GenerateUniqueUsername();
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
 
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var categoryPostDTO = new CategoryPostDTO
@@ -63,7 +63,7 @@ namespace VTA.Tests.UnitTests
             var username = _utilities.GenerateUniqueUsername();
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
 
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var categoryPostDTO = new CategoryPostDTO
@@ -108,7 +108,7 @@ namespace VTA.Tests.UnitTests
             var username = _utilities.GenerateUniqueUsername();
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
 
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var categoryPostDTO = new CategoryPostDTO

--- a/Backend/VTA.Tests/UnitTests/UserServiceTests.cs
+++ b/Backend/VTA.Tests/UnitTests/UserServiceTests.cs
@@ -22,7 +22,7 @@ namespace VTA.Tests.UnitTests
         {
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync("testuser", "testpassword", "Test User");
 
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var deleteStatus = await _utilities.DeleteUserAsync(signUpResult!.userId, signUpResult.Token);
@@ -35,7 +35,7 @@ namespace VTA.Tests.UnitTests
             var username = _utilities.GenerateUniqueUsername();
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync(username, "testpassword", "Test User");
 
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var request = new HttpRequestMessage(HttpMethod.Get, $"/api/Users/{signUpResult.userId}");
@@ -58,7 +58,7 @@ namespace VTA.Tests.UnitTests
         {
             var (signUpStatus, signUpResult) = await _utilities.SignUpUserAsync("testuser", "testpassword", "Test User");
 
-            Assert.Equal(HttpStatusCode.OK, signUpStatus);
+            Assert.Equal(HttpStatusCode.Created, signUpStatus);
             Assert.NotNull(signUpResult?.Token);
 
             var deleteStatus = await _utilities.DeleteUserAsync(signUpResult!.userId, signUpResult.Token);


### PR DESCRIPTION
## Summary
- Changes SignUp endpoint to return HTTP 201 (Created) instead of HTTP 200 (OK)
- Follows REST conventions for resource creation endpoints
- Adds `Location` header pointing to the newly created user resource
- Updates test helpers and test assertions to expect 201

## Test plan
- [x] Build passes
- [x] All 98 existing tests pass (updated to expect 201)
- [x] Verified `Location` header is returned with correct URI