### PR TITLE
fix: Provide default JWT secret for CI tests on fork PRs

### DIFF
--- a/Backend/VTA.API/Controllers/UsersController.cs
+++ b/Backend/VTA.API/Controllers/UsersController.cs
@@ -422,9 +422,13 @@ public class UsersController(VTAContext context, IConfiguration config) : Contro
     /// <exception cref="InvalidOperationException"></exception>
     private string GenerateJwt(User user)
     {
-        var secretKey = config.GetValue<string>("Secret:SecretKey")
-                        ?? Environment.GetEnvironmentVariable("JWT_SECRET") //Someone added this, why, i do not know, cause the key is stored in the appsettings.json not env variables
-                        ?? throw new InvalidOperationException("A JWT secret is required for token generation."); //Throw if no secret is found
+        // Get secret from configuration first, fall back to environment variable
+        // Use helper variables to properly handle empty strings (not just null)
+        var configSecret = config.GetValue<string>("Secret:SecretKey");
+        var envSecret = Environment.GetEnvironmentVariable("JWT_SECRET");
+        var secretKey = !string.IsNullOrWhiteSpace(configSecret) ? configSecret
+                      : !string.IsNullOrWhiteSpace(envSecret) ? envSecret
+                      : throw new InvalidOperationException("A JWT secret is required for token generation.");
         var validIssuer = "api.vta.com";
         var validAudience = "user.vta.com";
 

--- a/Backend/VTA.API/Program.cs
+++ b/Backend/VTA.API/Program.cs
@@ -42,18 +42,16 @@ builder.Services.AddSingleton(provider =>
     }
 );
 
-var config = new ConfigurationBuilder()
-    .SetBasePath(Directory.GetCurrentDirectory())
-    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-    .AddEnvironmentVariables()
-    .Build();
+// Get JWT secret from environment variable (for production/CI) or configuration (for development)
+// Use a helper to treat empty/whitespace strings the same as null
+var envSecret = Environment.GetEnvironmentVariable("JWT_SECRET");
+var jwtSecretKey = !string.IsNullOrWhiteSpace(envSecret)
+    ? envSecret
+    : builder.Configuration["Secret:SecretKey"];
 
-var jwtSecretKey = Environment.GetEnvironmentVariable("JWT_SECRET") //I still do not know why this was added, we are reading the Secretkey from appsettings, not the OS env variables
-                   ?? config["Secret:SecretKey"];//load our secret
-
-if (string.IsNullOrEmpty(jwtSecretKey))
+if (string.IsNullOrWhiteSpace(jwtSecretKey))
 {
-    throw new ArgumentNullException("JWT_SECRET_KEY environment variable or SecretKey in appsettings.json is required.");
+    throw new ArgumentNullException("JWT_SECRET environment variable or Secret:SecretKey in configuration is required.");
 }
 /*Configure Json Web Tokens*/
 var jwtIssuer = "api.vta.com";

--- a/Backend/VTA.Tests/TestHelpers/CustomApplicationFactory.cs
+++ b/Backend/VTA.Tests/TestHelpers/CustomApplicationFactory.cs
@@ -14,6 +14,18 @@ namespace VTA.Tests.TestHelpers
     {
         private readonly MySqlContainer _mySqlContainer;
 
+        // Static constructor runs once per AppDomain, before any instance is created.
+        // This ensures JWT_SECRET is set before WebApplicationFactory starts any host.
+        static CustomApplicationFactory()
+        {
+            // GitHub Actions doesn't expose secrets to fork PRs for security reasons.
+            // The workflow sets JWT_SECRET from secrets, but it resolves to empty string.
+            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("JWT_SECRET")))
+            {
+                Environment.SetEnvironmentVariable("JWT_SECRET", "test-jwt-secret-for-ci-must-be-at-least-32-chars");
+            }
+        }
+
         public CustomApplicationFactory()
         {
             var config = new ConfigurationBuilder()
@@ -26,19 +38,6 @@ namespace VTA.Tests.TestHelpers
             var connectionString = config.GetValue<string>("ConnectionStrings:TEST_CONNECTION_STRING")
                                    ?? Environment.GetEnvironmentVariable("TEST_CONNECTION_STRING")
                                    ?? "server=localhost;port=3306;user=vta_user;password=vta_password;database=vta_test";
-
-            var jwtSecretConfig = new JwtSecretConfig
-            {
-                SecretKey = config.GetValue<string>("Secret:SecretKey")
-                            ?? Environment.GetEnvironmentVariable("JWT_SECRET_KEY"),
-                ValidIssuer = config.GetValue<string>("Secret:ValidIssuer") ?? "api.vta.com",
-                ValidAudience = config.GetValue<string>("Secret:ValidAudience") ?? "user.vta.com"
-            };
-
-            if (string.IsNullOrEmpty(jwtSecretConfig.SecretKey))
-            {
-                throw new ArgumentNullException("A JWT secret is required for token generation.");
-            }
 
             var builder = new MySqlConnectionStringBuilder(connectionString);
             var database = string.IsNullOrEmpty(builder.Database) ? "vta_test" : builder.Database;
@@ -97,7 +96,12 @@ namespace VTA.Tests.TestHelpers
                 config
                     .AddJsonFile("/var/www/VTA.API/appsettings.json", optional: true)
                     .AddJsonFile("appsettings.json", optional: true)
-                    .AddEnvironmentVariables();
+                    .AddEnvironmentVariables()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Secret:SecretKey"] = Environment.GetEnvironmentVariable("JWT_SECRET_KEY")
+                                               ?? "test-jwt-secret-for-ci-must-be-at-least-32-chars"
+                    });
             });
 
             builder.ConfigureLogging(logging =>
@@ -108,11 +112,5 @@ namespace VTA.Tests.TestHelpers
             });
         }
 
-        private class JwtSecretConfig
-        {
-            public string? SecretKey { get; set; }
-            public string? ValidIssuer { get; set; }
-            public string? ValidAudience { get; set; }
-        }
     }
 }


### PR DESCRIPTION
## Summary

GitHub Actions doesn't expose secrets to fork PRs for security reasons. The workflow sets `JWT_SECRET` from secrets, but for forks it resolves to an empty string (not null). The `??` operator only checks for null, so empty strings were passing through and causing "key length is zero" errors at runtime.

## Changes

**Program.cs:**
- Remove duplicate ConfigurationBuilder (was inconsistent with builder.Configuration)
- Handle empty/whitespace strings explicitly with `IsNullOrWhiteSpace()`

**UsersController.cs:**
- Fix `GenerateJwt()` to handle empty strings the same way
- This was the actual source of the runtime "key length is zero" error

**CustomApplicationFactory.cs:**
- Use static constructor to set JWT_SECRET before any host creation
- Remove unused JwtSecretConfig class and null check
- Add AddInMemoryCollection for belt-and-suspenders config injection

## Test Plan

- [x] CI passes on this fork PR
- [x] All 98 VTA.Tests pass
- [x] All 25 SyncService.Tests pass

## Note

This PR should be merged first before other fork PRs, as it fixes CI for all fork contributions.