### PR TITLE
Phase 4.4: Sync retry logic, transaction safety, and SyncResult

### DIFF
--- a/Frontend/vta_app/lib/src/services/sync_downloader.dart
+++ b/Frontend/vta_app/lib/src/services/sync_downloader.dart
@@ -5,17 +5,35 @@ import 'package:get_it/get_it.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:vta_app/src/utilities/api/api_provider.dart';
+import 'package:vta_app/src/utilities/retry_helper.dart';
 import 'package:vta_app/src/singletons/token.dart';
 import 'package:vta_app/src/database/database.dart';
 import 'package:vta_app/src/singletons/user_info.dart';
+import 'package:vta_app/src/services/sync_models.dart';
 import 'package:logging/logging.dart';
+import 'package:sqflite/sqflite.dart';
 
 
 final _log = Logger('SyncDownloader');
+/// Result of a download pass for a single entity type.
+class DownloadResult {
+  final List<String> syncedIds;
+  final EntitySyncStats stats;
+  final List<SyncError> errors;
+
+  DownloadResult({
+    required this.syncedIds,
+    required this.stats,
+    List<SyncError>? errors,
+  }) : errors = errors ?? [];
+}
+
 /// Downloads entities from the backend and persists them in the local SQLite DB.
 ///
-/// Each `sync*` method handles one entity type. Assets (images, sounds) are
-/// downloaded to the app-support directory.
+/// Each `download*` method handles one entity type. Assets (images, sounds) are
+/// downloaded to the app-support directory. HTTP calls are wrapped in
+/// [RetryHelper] for transient-failure resilience, and DB writes are batched
+/// inside SQLite transactions.
 class SyncDownloader {
   final ApiProvider _apiProvider;
   final Token _token;
@@ -24,6 +42,7 @@ class SyncDownloader {
   final SavedBoardRepository _boardRepo;
   final CategoryRepository _categoryRepo;
   final SavedArtefactRepository _savedArtefactRepo;
+  final DatabaseHelper _dbHelper;
 
   SyncDownloader({
     ApiProvider? apiProvider,
@@ -33,273 +52,452 @@ class SyncDownloader {
     SavedBoardRepository? boardRepo,
     CategoryRepository? categoryRepo,
     SavedArtefactRepository? savedArtefactRepo,
+    DatabaseHelper? dbHelper,
   })  : _apiProvider = apiProvider ?? GetIt.instance.get<ApiProvider>(),
         _token = token ?? GetIt.instance.get<Token>(),
         _userInfo = userInfo ?? GetIt.instance.get<UserInfo>(),
         _artefactRepo = artefactRepo ?? ArtefactRepository(),
         _boardRepo = boardRepo ?? SavedBoardRepository(),
         _categoryRepo = categoryRepo ?? CategoryRepository(),
-        _savedArtefactRepo = savedArtefactRepo ?? SavedArtefactRepository();
+        _savedArtefactRepo = savedArtefactRepo ?? SavedArtefactRepository(),
+        _dbHelper = dbHelper ?? DatabaseHelper.instance;
 
   // ── Public download orchestrators ─────────────────────────────
 
   /// Download all artefacts from the backend.
   ///
-  /// Returns the list of artefact IDs that were synced so that the caller
-  /// can pass them to [SyncUploader] for the upload-missing step.
-  Future<List<String>> downloadArtefacts() async {
+  /// Returns a [DownloadResult] containing the list of synced IDs (for the
+  /// upload-missing step) plus per-entity stats and any errors.
+  Future<DownloadResult> downloadArtefacts() async {
+    final stats = EntitySyncStats(entityType: 'artefact');
+    final List<SyncError> errors = [];
     final List<String> syncedIds = [];
+
     try {
-      final response = await _apiProvider.fetchAsJson(
-        'Artefacts',
-        headers: {'Authorization': 'Bearer ${_token.value}'},
+      final result = await RetryHelper.runHttp(
+        () => _apiProvider.fetchAsJson(
+          'Artefacts',
+          headers: {'Authorization': 'Bearer ${_token.value}'},
+        ),
+        label: 'GET Artefacts',
       );
 
+      final response = result.value;
       if (response != null && response.statusCode == 200) {
         final List<dynamic> artefactsData = json.decode(response.body);
+
+        // Download assets before the transaction (network I/O)
+        final assetPaths = <String, _AssetPaths>{};
         for (final data in artefactsData) {
-          await _syncArtefact(data);
-          syncedIds.add(data['artefactId'] as String);
+          final artefactId = data['artefactId'] as String?;
+          if (artefactId == null) continue;
+          assetPaths[artefactId] = await _downloadArtefactAssets(data);
         }
+
+        // Batch DB writes inside a transaction
+        final db = await _dbHelper.database;
+        await db.transaction((txn) async {
+          for (final data in artefactsData) {
+            try {
+              final artefactId = data['artefactId'] as String?;
+              if (artefactId == null) {
+                stats.skipped++;
+                continue;
+              }
+              final wrote = await _syncArtefact(
+                  data, txn, assetPaths[artefactId] ?? _AssetPaths());
+              if (wrote) {
+                stats.succeeded++;
+              } else {
+                stats.skipped++;
+              }
+              syncedIds.add(artefactId);
+            } catch (e) {
+              stats.failed++;
+              errors.add(SyncError(
+                entityType: 'artefact',
+                entityId: data['artefactId'] as String?,
+                message: e.toString(),
+              ));
+              _log.warning('[SYNC] ERROR syncing artefact: $e');
+            }
+          }
+        });
+      } else {
+        errors.add(SyncError(
+          entityType: 'artefact',
+          message: 'HTTP ${response?.statusCode ?? "null"} fetching artefacts',
+        ));
       }
     } catch (e) {
-      _log.info('[SYNC] ERROR downloading artefacts: $e');
+      _log.warning('[SYNC] ERROR downloading artefacts: $e');
+      errors.add(SyncError(entityType: 'artefact', message: e.toString()));
     }
-    return syncedIds;
+    return DownloadResult(syncedIds: syncedIds, stats: stats, errors: errors);
   }
 
   /// Download all categories from the backend.
-  Future<List<String>> downloadCategories() async {
+  Future<DownloadResult> downloadCategories() async {
+    final stats = EntitySyncStats(entityType: 'category');
+    final List<SyncError> errors = [];
     final List<String> syncedIds = [];
+
     try {
-      final response = await _apiProvider.fetchAsJson(
-        'Categories',
-        headers: {'Authorization': 'Bearer ${_token.value}'},
+      final result = await RetryHelper.runHttp(
+        () => _apiProvider.fetchAsJson(
+          'Categories',
+          headers: {'Authorization': 'Bearer ${_token.value}'},
+        ),
+        label: 'GET Categories',
       );
 
+      final response = result.value;
       if (response != null && response.statusCode == 200) {
         final List<dynamic> categoriesData = json.decode(response.body);
+
+        // Download assets before the transaction (network I/O)
+        final assetPaths = <String, String?>{};
         for (final data in categoriesData) {
-          await _syncCategory(data);
-          syncedIds.add(data['categoryId'] as String);
+          final categoryId = data['categoryId'] as String?;
+          if (categoryId == null) continue;
+          final imageUrl = data['imageUrl'] as String?;
+          if (imageUrl != null && imageUrl.isNotEmpty) {
+            assetPaths[categoryId] = await _downloadAsset(
+              imageUrl,
+              'Categories',
+              'image_$categoryId',
+              _userInfo.userId ?? '',
+            );
+          }
         }
+
+        // Batch DB writes inside a transaction
+        final db = await _dbHelper.database;
+        await db.transaction((txn) async {
+          for (final data in categoriesData) {
+            try {
+              final categoryId = data['categoryId'] as String?;
+              if (categoryId == null) {
+                stats.skipped++;
+                continue;
+              }
+              final wrote = await _syncCategory(
+                  data, txn, assetPaths[categoryId]);
+              if (wrote) {
+                stats.succeeded++;
+              } else {
+                stats.skipped++;
+              }
+              syncedIds.add(categoryId);
+            } catch (e) {
+              stats.failed++;
+              errors.add(SyncError(
+                entityType: 'category',
+                entityId: data['categoryId'] as String?,
+                message: e.toString(),
+              ));
+              _log.warning('[SYNC] ERROR syncing category: $e');
+            }
+          }
+        });
+      } else {
+        errors.add(SyncError(
+          entityType: 'category',
+          message:
+              'HTTP ${response?.statusCode ?? "null"} fetching categories',
+        ));
       }
     } catch (e) {
-      _log.info('[SYNC] ERROR downloading categories: $e');
+      _log.warning('[SYNC] ERROR downloading categories: $e');
+      errors.add(SyncError(entityType: 'category', message: e.toString()));
     }
-    return syncedIds;
+    return DownloadResult(syncedIds: syncedIds, stats: stats, errors: errors);
   }
 
   /// Download all boards (with their saved artefacts) from the backend.
-  Future<List<String>> downloadBoards() async {
+  Future<DownloadResult> downloadBoards() async {
+    final stats = EntitySyncStats(entityType: 'board');
+    final List<SyncError> errors = [];
     final List<String> syncedIds = [];
+
     try {
-      final response = await _apiProvider.fetchAsJson(
-        'Boards',
-        headers: {'Authorization': 'Bearer ${_token.value}'},
+      final result = await RetryHelper.runHttp(
+        () => _apiProvider.fetchAsJson(
+          'Boards',
+          headers: {'Authorization': 'Bearer ${_token.value}'},
+        ),
+        label: 'GET Boards',
       );
 
+      final response = result.value;
       if (response != null && response.statusCode == 200) {
         final List<dynamic> boardsData = json.decode(response.body);
-        for (final data in boardsData) {
-          await _syncBoard(data);
-          syncedIds.add(data['boardId'] as String? ?? data['id'] as String);
-        }
+
+        // Batch DB writes inside a transaction
+        final db = await _dbHelper.database;
+        await db.transaction((txn) async {
+          for (final data in boardsData) {
+            try {
+              final boardId =
+                  data['boardId'] as String? ?? data['id'] as String?;
+              if (boardId == null) {
+                stats.skipped++;
+                continue;
+              }
+              final wrote = await _syncBoard(data, txn);
+              if (wrote) {
+                stats.succeeded++;
+              } else {
+                stats.skipped++;
+              }
+              syncedIds.add(boardId);
+            } catch (e) {
+              stats.failed++;
+              final boardId =
+                  data['boardId'] as String? ?? data['id'] as String?;
+              errors.add(SyncError(
+                entityType: 'board',
+                entityId: boardId,
+                message: e.toString(),
+              ));
+              _log.warning('[SYNC] ERROR syncing board: $e');
+            }
+          }
+        });
+      } else {
+        errors.add(SyncError(
+          entityType: 'board',
+          message: 'HTTP ${response?.statusCode ?? "null"} fetching boards',
+        ));
       }
     } catch (e) {
-      _log.info('[SYNC] ERROR downloading boards: $e');
+      _log.warning('[SYNC] ERROR downloading boards: $e');
+      errors.add(SyncError(entityType: 'board', message: e.toString()));
     }
-    return syncedIds;
+    return DownloadResult(syncedIds: syncedIds, stats: stats, errors: errors);
   }
 
   // ── Private per-entity sync ───────────────────────────────────
 
-  Future<void> _syncArtefact(Map<String, dynamic> data) async {
-    try {
-      final artefactId = data['artefactId'] as String?;
-      if (artefactId == null) return;
+  /// Pre-downloaded asset paths for an artefact.
+  Future<_AssetPaths> _downloadArtefactAssets(
+      Map<String, dynamic> data) async {
+    String? localImagePath;
+    String? localSoundPath;
 
-      final existing = await _artefactRepo.getById(artefactId);
-
-      final backendModifiedDate = _parseDate(data['modifiedDate'] as String?);
-      final syncDirection =
-          _decideSyncDirection(existing?.modifiedDate, backendModifiedDate);
-
-      if (syncDirection != 'download') return;
-
-      // Download image and sound files if they have URLs
-      String? localImagePath;
-      String? localSoundPath;
-
-      final imageUrl = data['imageUrl'] as String?;
-      if (imageUrl != null && imageUrl.isNotEmpty) {
-        localImagePath = await _downloadAsset(
-          imageUrl,
-          'Artefacts',
-          'image_$artefactId',
-          _userInfo.userId ?? '',
-        );
-      }
-
-      final soundUrl = data['soundUrl'] as String?;
-      if (soundUrl != null && soundUrl.isNotEmpty) {
-        localSoundPath = await _downloadAsset(
-          soundUrl,
-          'Sounds',
-          'sound_$artefactId',
-          _userInfo.userId ?? '',
-        );
-      }
-
-      final artefact = ArtefactDB(
-        artefactId: artefactId,
-        artefactIndex: data['artefactIndex'] as int? ?? 0,
-        userId: data['userId'] as String? ?? _userInfo.userId ?? '',
-        categoryId: data['categoryId'] as String?,
-        imagePath: localImagePath ?? _extractFilename(imageUrl),
-        soundPath: localSoundPath ?? _extractFilename(soundUrl),
-        modifiedDate: _parseDate(data['modifiedDate'] as String?),
-        name: data['name'] as String?,
-        nameShown: (data['nameShown'] as bool?) == true ? 1 : 0,
-        isDeleted: (data['isDeleted'] as bool?) == true ? 1 : 0,
+    final imageUrl = data['imageUrl'] as String?;
+    if (imageUrl != null && imageUrl.isNotEmpty) {
+      localImagePath = await _downloadAsset(
+        imageUrl,
+        'Artefacts',
+        'image_${data['artefactId']}',
+        _userInfo.userId ?? '',
       );
-
-      if (existing != null) {
-        await _artefactRepo.update(artefact);
-      } else {
-        await _artefactRepo.insert(artefact);
-      }
-    } catch (e) {
-      _log.info('[SYNC] ERROR syncing artefact: $e');
     }
+
+    final soundUrl = data['soundUrl'] as String?;
+    if (soundUrl != null && soundUrl.isNotEmpty) {
+      localSoundPath = await _downloadAsset(
+        soundUrl,
+        'Sounds',
+        'sound_${data['artefactId']}',
+        _userInfo.userId ?? '',
+      );
+    }
+
+    return _AssetPaths(imagePath: localImagePath, soundPath: localSoundPath);
   }
 
-  Future<void> _syncCategory(Map<String, dynamic> data) async {
-    try {
-      final categoryId = data['categoryId'] as String?;
-      if (categoryId == null) return;
+  /// Returns `true` if the entity was written, `false` if skipped.
+  Future<bool> _syncArtefact(
+    Map<String, dynamic> data,
+    Transaction txn,
+    _AssetPaths assets,
+  ) async {
+    final artefactId = data['artefactId'] as String?;
+    if (artefactId == null) return false;
 
-      final existing = await _categoryRepo.getById(categoryId);
+    final existing = await _artefactRepo.getById(artefactId);
 
-      final backendModifiedDate = _parseDate(data['modifiedDate'] as String?);
-      final syncDirection =
-          _decideSyncDirection(existing?.modifiedDate, backendModifiedDate);
+    final backendModifiedDate = _parseDate(data['modifiedDate'] as String?);
+    final syncDirection =
+        _decideSyncDirection(existing?.modifiedDate, backendModifiedDate);
 
-      if (syncDirection != 'download') return;
+    if (syncDirection != 'download') return false;
 
-      String? localImagePath;
-      final imageUrl = data['imageUrl'] as String?;
-      if (imageUrl != null && imageUrl.isNotEmpty) {
-        localImagePath = await _downloadAsset(
-          imageUrl,
-          'Categories',
-          'image_$categoryId',
-          _userInfo.userId ?? '',
-        );
-      }
+    final imageUrl = data['imageUrl'] as String?;
+    final soundUrl = data['soundUrl'] as String?;
 
-      final category = CategoryDB(
-        categoryId: categoryId,
-        categoryIndex: data['categoryIndex'] as int?,
-        userId: data['userId'] as String? ?? _userInfo.userId ?? '',
-        name: data['name'] as String?,
-        imagePath: localImagePath ?? _extractFilename(imageUrl),
-        modifiedDate: _parseDate(data['modifiedDate'] as String?),
-        usageCount: data['usageCount'] as int? ?? 0,
-        lastUsedDate: _parseDate(data['lastUsedDate'] as String?),
-        isDeleted: (data['isDeleted'] as bool?) == true ? 1 : 0,
+    final artefact = ArtefactDB(
+      artefactId: artefactId,
+      artefactIndex: data['artefactIndex'] as int? ?? 0,
+      userId: data['userId'] as String? ?? _userInfo.userId ?? '',
+      categoryId: data['categoryId'] as String?,
+      imagePath: assets.imagePath ?? _extractFilename(imageUrl),
+      soundPath: assets.soundPath ?? _extractFilename(soundUrl),
+      modifiedDate: _parseDate(data['modifiedDate'] as String?),
+      name: data['name'] as String?,
+      nameShown: (data['nameShown'] as bool?) == true ? 1 : 0,
+      isDeleted: (data['isDeleted'] as bool?) == true ? 1 : 0,
+    );
+
+    if (existing != null) {
+      await txn.update(
+        'artefact',
+        artefact.toMap(),
+        where: 'artefact_id = ?',
+        whereArgs: [artefact.artefactId],
       );
-
-      if (existing != null) {
-        await _categoryRepo.update(category);
-      } else {
-        await _categoryRepo.insert(category);
-      }
-    } catch (e) {
-      _log.info('[SYNC] ERROR syncing category: $e');
+    } else {
+      await txn.insert(
+        'artefact',
+        artefact.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
     }
+    return true;
   }
 
-  Future<void> _syncBoard(Map<String, dynamic> data) async {
-    try {
-      final boardId = data['boardId'] as String? ?? data['id'] as String?;
-      if (boardId == null) return;
+  /// Returns `true` if the entity was written, `false` if skipped.
+  Future<bool> _syncCategory(
+    Map<String, dynamic> data,
+    Transaction txn,
+    String? localImagePath,
+  ) async {
+    final categoryId = data['categoryId'] as String?;
+    if (categoryId == null) return false;
 
-      final existing = await _boardRepo.getById(boardId);
+    final existing = await _categoryRepo.getById(categoryId);
 
-      final backendModifiedDate = _parseDate(data['modifiedDate'] as String?);
-      final syncDirection =
-          _decideSyncDirection(existing?.modifiedDate, backendModifiedDate);
+    final backendModifiedDate = _parseDate(data['modifiedDate'] as String?);
+    final syncDirection =
+        _decideSyncDirection(existing?.modifiedDate, backendModifiedDate);
 
-      if (syncDirection != 'download') return;
+    if (syncDirection != 'download') return false;
 
-      final artefactIds = (data['artefactIds'] as List<dynamic>?)
-          ?.map((id) => id.toString())
-          .join(',');
-      final savedArtefactIds = (data['savedArtefactIds'] as List<dynamic>?)
-          ?.map((id) => id.toString())
-          .join(',');
+    final imageUrl = data['imageUrl'] as String?;
 
-      final board = SavedBoardDB(
-        id: boardId,
-        name: data['name'] as String? ?? 'Unnamed Board',
-        userId: data['userId'] as String? ?? _userInfo.userId ?? '',
-        savedArtefactIds: savedArtefactIds,
-        artefactIds: artefactIds,
-        snapshotPath: _extractFilename(data['snapshotUrl'] as String?),
-        createdDate: _parseDate(data['createdDate'] as String?) ??
-            (DateTime.now().millisecondsSinceEpoch ~/ 1000),
-        modifiedDate: _parseDate(data['modifiedDate'] as String?),
-        isDeleted: (data['isDeleted'] as bool?) == true ? 1 : 0,
+    final category = CategoryDB(
+      categoryId: categoryId,
+      categoryIndex: data['categoryIndex'] as int?,
+      userId: data['userId'] as String? ?? _userInfo.userId ?? '',
+      name: data['name'] as String?,
+      imagePath: localImagePath ?? _extractFilename(imageUrl),
+      modifiedDate: _parseDate(data['modifiedDate'] as String?),
+      usageCount: data['usageCount'] as int? ?? 0,
+      lastUsedDate: _parseDate(data['lastUsedDate'] as String?),
+      isDeleted: (data['isDeleted'] as bool?) == true ? 1 : 0,
+    );
+
+    if (existing != null) {
+      await txn.update(
+        'category',
+        category.toMap(),
+        where: 'category_id = ?',
+        whereArgs: [category.categoryId],
       );
-
-      if (existing != null) {
-        await _boardRepo.update(board);
-      } else {
-        await _boardRepo.insert(board);
-      }
-
-      // Sync saved artefacts for this board
-      final savedArtefacts = data['savedArtefacts'] as List<dynamic>?;
-      if (savedArtefacts != null) {
-        for (final savedArtefactData in savedArtefacts) {
-          await _syncSavedArtefact(savedArtefactData, boardId);
-        }
-      }
-    } catch (e) {
-      _log.info('[SYNC] ERROR syncing board: $e');
+    } else {
+      await txn.insert(
+        'category',
+        category.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
     }
+    return true;
+  }
+
+  /// Returns `true` if the entity was written, `false` if skipped.
+  Future<bool> _syncBoard(Map<String, dynamic> data, Transaction txn) async {
+    final boardId = data['boardId'] as String? ?? data['id'] as String?;
+    if (boardId == null) return false;
+
+    final existing = await _boardRepo.getById(boardId);
+
+    final backendModifiedDate = _parseDate(data['modifiedDate'] as String?);
+    final syncDirection =
+        _decideSyncDirection(existing?.modifiedDate, backendModifiedDate);
+
+    if (syncDirection != 'download') return false;
+
+    final artefactIds = (data['artefactIds'] as List<dynamic>?)
+        ?.map((id) => id.toString())
+        .join(',');
+    final savedArtefactIds = (data['savedArtefactIds'] as List<dynamic>?)
+        ?.map((id) => id.toString())
+        .join(',');
+
+    final board = SavedBoardDB(
+      id: boardId,
+      name: data['name'] as String? ?? 'Unnamed Board',
+      userId: data['userId'] as String? ?? _userInfo.userId ?? '',
+      savedArtefactIds: savedArtefactIds,
+      artefactIds: artefactIds,
+      snapshotPath: _extractFilename(data['snapshotUrl'] as String?),
+      createdDate: _parseDate(data['createdDate'] as String?) ??
+          (DateTime.now().millisecondsSinceEpoch ~/ 1000),
+      modifiedDate: _parseDate(data['modifiedDate'] as String?),
+      isDeleted: (data['isDeleted'] as bool?) == true ? 1 : 0,
+    );
+
+    if (existing != null) {
+      await txn.update(
+        'saved_board',
+        board.toMap(),
+        where: 'id = ?',
+        whereArgs: [board.id],
+      );
+    } else {
+      await txn.insert(
+        'saved_board',
+        board.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+    }
+
+    // Sync saved artefacts for this board
+    final savedArtefacts = data['savedArtefacts'] as List<dynamic>?;
+    if (savedArtefacts != null) {
+      for (final savedArtefactData in savedArtefacts) {
+        await _syncSavedArtefact(savedArtefactData, boardId, txn);
+      }
+    }
+    return true;
   }
 
   Future<void> _syncSavedArtefact(
-      Map<String, dynamic> data, String boardId) async {
-    try {
-      final id = data['id'] as String?;
-      if (id == null) return;
+      Map<String, dynamic> data, String boardId, Transaction txn) async {
+    final id = data['id'] as String?;
+    if (id == null) return;
 
-      final savedArtefact = SavedArtefactDB(
-        id: id,
-        artefactId: data['artefactId'] as String? ?? '',
-        boardId: boardId,
-        posX: (data['posX'] as num?)?.toDouble() ?? 0.0,
-        posY: (data['posY'] as num?)?.toDouble() ?? 0.0,
-        width: (data['width'] as num?)?.toDouble() ?? 200.0,
-        height: (data['height'] as num?)?.toDouble() ?? 200.0,
-        createdDate: _parseDate(data['createdDate'] as String?) ??
-            (DateTime.now().millisecondsSinceEpoch ~/ 1000),
-        modifiedDate: _parseDate(data['modifiedDate'] as String?),
-        nameVisible: (data['nameVisible'] as bool?) == true ? 1 : null,
-        isDeleted: (data['isDeleted'] as bool?) == true ? 1 : 0,
+    final savedArtefact = SavedArtefactDB(
+      id: id,
+      artefactId: data['artefactId'] as String? ?? '',
+      boardId: boardId,
+      posX: (data['posX'] as num?)?.toDouble() ?? 0.0,
+      posY: (data['posY'] as num?)?.toDouble() ?? 0.0,
+      width: (data['width'] as num?)?.toDouble() ?? 200.0,
+      height: (data['height'] as num?)?.toDouble() ?? 200.0,
+      createdDate: _parseDate(data['createdDate'] as String?) ??
+          (DateTime.now().millisecondsSinceEpoch ~/ 1000),
+      modifiedDate: _parseDate(data['modifiedDate'] as String?),
+      nameVisible: (data['nameVisible'] as bool?) == true ? 1 : null,
+      isDeleted: (data['isDeleted'] as bool?) == true ? 1 : 0,
+    );
+
+    final existing = await _savedArtefactRepo.getById(id);
+    if (existing != null) {
+      await txn.update(
+        'saved_artefact',
+        savedArtefact.toMap(),
+        where: 'id = ?',
+        whereArgs: [savedArtefact.id],
       );
-
-      final existing = await _savedArtefactRepo.getById(id);
-      if (existing != null) {
-        await _savedArtefactRepo.update(savedArtefact);
-      } else {
-        await _savedArtefactRepo.insert(savedArtefact);
-      }
-    } catch (e) {
-      _log.info('[SYNC] ERROR syncing saved artefact: $e');
+    } else {
+      await txn.insert(
+        'saved_artefact',
+        savedArtefact.toMap(),
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
     }
   }
 
@@ -316,6 +514,8 @@ class SyncDownloader {
   }
 
   /// Download an asset (image / sound) and write it to local storage.
+  ///
+  /// Uses [RetryHelper] for transient network failures.
   Future<String?> _downloadAsset(
     String url,
     String assetType,
@@ -326,11 +526,20 @@ class SyncDownloader {
       final fullUrl =
           url.startsWith('http') ? url : _apiProvider.baseUrl + url;
 
-      final response = await http.get(
-        Uri.parse(fullUrl),
-        headers: {'Authorization': 'Bearer ${_token.value}'},
+      final result = await RetryHelper.run(
+        () => http.get(
+          Uri.parse(fullUrl),
+          headers: {'Authorization': 'Bearer ${_token.value}'},
+        ),
+        label: 'GET asset $filename',
       );
 
+      if (!result.succeeded) {
+        _log.info('[SYNC] Failed to download asset after retries: $fullUrl');
+        return null;
+      }
+
+      final response = result.value!;
       if (response.statusCode != 200) {
         _log.info(
             '[SYNC] Failed to download asset: ${response.statusCode} - $fullUrl');
@@ -373,4 +582,11 @@ class SyncDownloader {
       return null;
     }
   }
+}
+
+/// Pre-downloaded asset paths for an artefact.
+class _AssetPaths {
+  final String? imagePath;
+  final String? soundPath;
+  _AssetPaths({this.imagePath, this.soundPath});
 }

--- a/Frontend/vta_app/lib/src/services/sync_models.dart
+++ b/Frontend/vta_app/lib/src/services/sync_models.dart
@@ -4,6 +4,114 @@
 /// [SyncChangeDetector], [SyncDownloader], [SyncUploader], and [SyncService].
 library;
 
+// ── SyncResult ──────────────────────────────────────────────────
+
+/// Counts of entities processed during a single entity-type sync pass.
+class EntitySyncStats {
+  final String entityType;
+  int succeeded;
+  int failed;
+  int skipped;
+
+  EntitySyncStats({
+    required this.entityType,
+    this.succeeded = 0,
+    this.failed = 0,
+    this.skipped = 0,
+  });
+
+  int get total => succeeded + failed + skipped;
+
+  @override
+  String toString() =>
+      '$entityType(ok: $succeeded, fail: $failed, skip: $skipped)';
+}
+
+/// Detailed record of a single sync error.
+class SyncError {
+  final String entityType;
+  final String? entityId;
+  final String message;
+  final DateTime timestamp;
+
+  SyncError({
+    required this.entityType,
+    this.entityId,
+    required this.message,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  @override
+  String toString() =>
+      'SyncError($entityType${entityId != null ? '/$entityId' : ''}: $message)';
+}
+
+/// Aggregated result of a full bidirectional sync operation.
+///
+/// Replaces the old `bool` return from [SyncService.syncFromServer].
+class SyncResult {
+  final Map<String, EntitySyncStats> downloadStats;
+  final Map<String, EntitySyncStats> uploadStats;
+  final List<SyncError> errors;
+  final DateTime startedAt;
+  final DateTime completedAt;
+
+  SyncResult({
+    required this.downloadStats,
+    required this.uploadStats,
+    List<SyncError>? errors,
+    required this.startedAt,
+    DateTime? completedAt,
+  })  : errors = errors ?? [],
+        completedAt = completedAt ?? DateTime.now();
+
+  /// `true` when every entity type completed without errors.
+  bool get success => errors.isEmpty;
+
+  /// `true` when at least one entity synced but there were also errors.
+  bool get partial =>
+      errors.isNotEmpty &&
+      (downloadStats.values.any((s) => s.succeeded > 0) ||
+          uploadStats.values.any((s) => s.succeeded > 0));
+
+  int get totalDownloaded =>
+      downloadStats.values.fold(0, (sum, s) => sum + s.succeeded);
+
+  int get totalUploaded =>
+      uploadStats.values.fold(0, (sum, s) => sum + s.succeeded);
+
+  int get totalFailed =>
+      downloadStats.values.fold(0, (sum, s) => sum + s.failed) +
+      uploadStats.values.fold(0, (sum, s) => sum + s.failed);
+
+  Duration get duration => completedAt.difference(startedAt);
+
+  /// Create a failed result when sync cannot even start (e.g. no user ID).
+  factory SyncResult.aborted(String reason) {
+    final now = DateTime.now();
+    return SyncResult(
+      downloadStats: {},
+      uploadStats: {},
+      errors: [SyncError(entityType: 'sync', message: reason)],
+      startedAt: now,
+      completedAt: now,
+    );
+  }
+
+  @override
+  String toString() {
+    final buf = StringBuffer('SyncResult(');
+    buf.write('success: $success, ');
+    buf.write('downloaded: $totalDownloaded, ');
+    buf.write('uploaded: $totalUploaded, ');
+    buf.write('failed: $totalFailed, ');
+    buf.write('errors: ${errors.length}, ');
+    buf.write('duration: ${duration.inMilliseconds}ms');
+    buf.write(')');
+    return buf.toString();
+  }
+}
+
 /// Model representing a file change record
 class FileChangeRecord {
   final String fileId;

--- a/Frontend/vta_app/lib/src/services/sync_service.dart
+++ b/Frontend/vta_app/lib/src/services/sync_service.dart
@@ -9,6 +9,9 @@ import 'package:logging/logging.dart';
 
 // Re-export models so existing `import 'sync_service.dart'` still works.
 export 'package:vta_app/src/services/sync_models.dart';
+// Re-export result types used by callers.
+export 'package:vta_app/src/services/sync_downloader.dart' show DownloadResult;
+export 'package:vta_app/src/services/sync_uploader.dart' show UploadResult;
 
 final _log = Logger('SyncService');
 
@@ -51,38 +54,82 @@ class SyncService {
 
   /// Download all entities from the server, then upload any that are
   /// missing on the backend. Updates the sync-metadata timestamp.
-  Future<bool> syncFromServer({DateTime? since}) async {
+  ///
+  /// Returns a [SyncResult] with per-entity-type stats and any errors.
+  Future<SyncResult> syncFromServer({DateTime? since}) async {
+    final startedAt = DateTime.now();
     try {
       final userId = _userInfo.userId;
-      if (userId == null) return false;
+      if (userId == null) return SyncResult.aborted('No user ID');
 
-      // 1. Download all entity types, collecting synced IDs
-      final syncedArtefactIds = await _downloader.downloadArtefacts();
-      await _uploader.uploadLocalArtefacts(syncedArtefactIds);
+      final Map<String, EntitySyncStats> downloadStats = {};
+      final Map<String, EntitySyncStats> uploadStats = {};
+      final List<SyncError> errors = [];
 
-      final syncedCategoryIds = await _downloader.downloadCategories();
-      await _uploader.uploadLocalCategories(syncedCategoryIds);
+      // 1. Download + upload artefacts
+      final dlArtefacts = await _downloader.downloadArtefacts();
+      downloadStats['artefact'] = dlArtefacts.stats;
+      errors.addAll(dlArtefacts.errors);
 
-      final syncedBoardIds = await _downloader.downloadBoards();
-      await _uploader.uploadLocalBoards(syncedBoardIds);
+      final ulArtefacts =
+          await _uploader.uploadLocalArtefacts(dlArtefacts.syncedIds);
+      uploadStats['artefact'] = ulArtefacts.stats;
+      errors.addAll(ulArtefacts.errors);
 
-      // 2. Mark sync timestamp
+      // 2. Download + upload categories
+      final dlCategories = await _downloader.downloadCategories();
+      downloadStats['category'] = dlCategories.stats;
+      errors.addAll(dlCategories.errors);
+
+      final ulCategories =
+          await _uploader.uploadLocalCategories(dlCategories.syncedIds);
+      uploadStats['category'] = ulCategories.stats;
+      errors.addAll(ulCategories.errors);
+
+      // 3. Download + upload boards
+      final dlBoards = await _downloader.downloadBoards();
+      downloadStats['board'] = dlBoards.stats;
+      errors.addAll(dlBoards.errors);
+
+      final ulBoards =
+          await _uploader.uploadLocalBoards(dlBoards.syncedIds);
+      uploadStats['board'] = ulBoards.stats;
+      errors.addAll(ulBoards.errors);
+
+      // 4. Mark sync timestamp
       await _syncMetaRepo.updateLastSyncDate(userId, 'all', DateTime.now());
 
-      return true;
+      final result = SyncResult(
+        downloadStats: downloadStats,
+        uploadStats: uploadStats,
+        errors: errors,
+        startedAt: startedAt,
+      );
+
+      _log.info('[SYNC] Completed: $result');
+      return result;
     } catch (e) {
-      _log.info('[SYNC] ERROR in syncFromServer: $e');
-      return false;
+      _log.warning('[SYNC] ERROR in syncFromServer: $e');
+      return SyncResult(
+        downloadStats: {},
+        uploadStats: {},
+        errors: [SyncError(entityType: 'sync', message: e.toString())],
+        startedAt: startedAt,
+      );
     }
   }
 
   /// Perform a full sync if needed (based on [threshold]).
-  Future<bool> autoSync(
+  Future<SyncResult> autoSync(
       {Duration threshold = const Duration(hours: 1)}) async {
     if (await needsSync(threshold: threshold)) {
       return await syncFromServer();
     }
-    return true;
+    return SyncResult(
+      downloadStats: {},
+      uploadStats: {},
+      startedAt: DateTime.now(),
+    );
   }
 
   // ── Change detection (delegated) ──────────────────────────────

--- a/Frontend/vta_app/lib/src/services/sync_timer.dart
+++ b/Frontend/vta_app/lib/src/services/sync_timer.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 import 'package:get_it/get_it.dart';
 import 'package:vta_app/src/services/sync_service.dart';
 import 'package:vta_app/src/singletons/user_info.dart';
@@ -6,8 +7,18 @@ import 'package:logging/logging.dart';
 
 
 final _log = Logger('SyncTimer');
-/// Service that manages periodic syncing with the backend
-/// Runs sync operations on a timer and provides lifecycle management
+
+/// Default interval between sync attempts.
+const _defaultInterval = Duration(seconds: 30);
+
+/// Maximum interval after consecutive failures (5 minutes).
+const _maxInterval = Duration(minutes: 5);
+
+/// Service that manages periodic syncing with the backend.
+///
+/// On consecutive failures the timer interval grows exponentially
+/// (30 s → 60 s → 120 s → … up to 5 min). A successful sync resets the
+/// interval to the default.
 class SyncTimer {
   static final SyncTimer _instance = SyncTimer._internal();
   factory SyncTimer() => _instance;
@@ -19,47 +30,63 @@ class SyncTimer {
   bool _isRunning = false;
   int _syncCount = 0;
 
-  /// Start the periodic sync timer
-  /// [interval] - Duration between sync attempts (default: 30 seconds)
-  void start({Duration interval = const Duration(seconds: 30)}) {
+  /// Number of consecutive failed sync cycles.
+  int _consecutiveFailures = 0;
+
+  /// The current (possibly backed-off) interval.
+  Duration _currentInterval = _defaultInterval;
+
+  /// The base interval configured at [start].
+  Duration _baseInterval = _defaultInterval;
+
+  /// Start the periodic sync timer.
+  ///
+  /// [interval] — Duration between sync attempts when everything is healthy.
+  void start({Duration interval = _defaultInterval}) {
     if (_isRunning) {
       stop();
     }
     
     try {
-      // Get the singleton UserInfo from GetIt
       _userInfo = GetIt.I.get<UserInfo>();
       _log.info('[SYNC-TIMER] Starting periodic sync (${interval.inSeconds}s interval)');
     } catch (e) {
-      _log.info('[SYNC-TIMER] ERROR: Failed to get UserInfo: $e');
+      _log.warning('[SYNC-TIMER] Failed to get UserInfo: $e');
       return;
     }
     
     _isRunning = true;
     _syncCount = 0;
+    _consecutiveFailures = 0;
+    _baseInterval = interval;
+    _currentInterval = interval;
 
     // Run initial sync immediately
     _performSync();
 
     // Set up periodic timer
-    try {
-      _timer = Timer.periodic(interval, (timer) {
-        _performSync();
-      });
-    } catch (e) {
-      _log.info('[SYNC-TIMER] ERROR creating timer: $e');
-      _isRunning = false;
-    }
+    _scheduleNext();
   }
 
-  /// Stop the periodic sync timer
+  /// Stop the periodic sync timer.
   void stop() {
     _timer?.cancel();
     _timer = null;
     _isRunning = false;
   }
 
-  /// Perform a single sync operation
+  /// Schedule the next sync tick using [_currentInterval].
+  void _scheduleNext() {
+    _timer?.cancel();
+    if (!_isRunning) return;
+
+    _timer = Timer(_currentInterval, () {
+      _performSync();
+      _scheduleNext();
+    });
+  }
+
+  /// Perform a single sync operation and adjust backoff on failure.
   Future<void> _performSync() async {
     _syncCount++;
     
@@ -67,32 +94,63 @@ class SyncTimer {
     if (userId == null || userId.isEmpty) return;
 
     try {
-      // Use autoSync which checks if sync is needed based on threshold
-      // Set threshold to 0 to force sync every time
-      final success = await _syncService.autoSync(
-        threshold: Duration.zero, // Always sync when called
+      final result = await _syncService.autoSync(
+        threshold: Duration.zero,
       );
       
-      if (!success) {
-        _log.info('[SYNC-TIMER] Sync failed');
+      if (result.success) {
+        if (_consecutiveFailures > 0) {
+          _log.info(
+            '[SYNC-TIMER] Sync recovered after $_consecutiveFailures failures. '
+            'Resetting interval to ${_baseInterval.inSeconds}s.',
+          );
+        }
+        _consecutiveFailures = 0;
+        _currentInterval = _baseInterval;
+      } else {
+        _onFailure();
       }
     } catch (e) {
-      _log.info('[SYNC-TIMER] ERROR during sync: $e');
+      _log.warning('[SYNC-TIMER] ERROR during sync: $e');
+      _onFailure();
     }
   }
 
-  /// Manually trigger a sync outside the timer
+  /// Increase backoff after a failure.
+  void _onFailure() {
+    _consecutiveFailures++;
+    _currentInterval = Duration(
+      milliseconds: min(
+        (_baseInterval.inMilliseconds * pow(2, _consecutiveFailures)).toInt(),
+        _maxInterval.inMilliseconds,
+      ),
+    );
+    _log.info(
+      '[SYNC-TIMER] Sync failed ($_consecutiveFailures in a row). '
+      'Next attempt in ${_currentInterval.inSeconds}s.',
+    );
+    // Reschedule with new interval
+    _scheduleNext();
+  }
+
+  /// Manually trigger a sync outside the timer.
   Future<void> syncNow() async {
     await _performSync();
   }
 
-  /// Check if the timer is currently running
+  /// Check if the timer is currently running.
   bool get isRunning => _isRunning;
 
-  /// Get the current sync service instance
+  /// Get the current sync service instance.
   SyncService get syncService => _syncService;
+
+  /// Number of consecutive failures.
+  int get consecutiveFailures => _consecutiveFailures;
+
+  /// Current (possibly backed-off) interval.
+  Duration get currentInterval => _currentInterval;
   
-  /// Get current status for debugging
+  /// Get current status for debugging.
   String getStatus() {
     return '''
 [SYNC-TIMER] Status Report:
@@ -100,11 +158,13 @@ class SyncTimer {
   - timer exists: ${_timer != null}
   - timer is active: ${_timer?.isActive ?? false}
   - sync count: $_syncCount
+  - consecutive failures: $_consecutiveFailures
+  - current interval: ${_currentInterval.inSeconds}s
   - user ID: ${_userInfo.userId ?? "not initialized"}
 ''';
   }
   
-  /// Print current status
+  /// Print current status.
   void printStatus() {
     _log.info(getStatus());
   }

--- a/Frontend/vta_app/lib/src/services/sync_uploader.dart
+++ b/Frontend/vta_app/lib/src/services/sync_uploader.dart
@@ -5,17 +5,32 @@ import 'package:get_it/get_it.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:vta_app/src/utilities/api/api_provider.dart';
+import 'package:vta_app/src/utilities/retry_helper.dart';
 import 'package:vta_app/src/singletons/token.dart';
 import 'package:vta_app/src/database/database.dart';
 import 'package:vta_app/src/singletons/user_info.dart';
+import 'package:vta_app/src/services/sync_models.dart';
 import 'package:logging/logging.dart';
 
 
 final _log = Logger('SyncUploader');
+
+/// Result of an upload pass for a single entity type.
+class UploadResult {
+  final EntitySyncStats stats;
+  final List<SyncError> errors;
+
+  UploadResult({
+    required this.stats,
+    List<SyncError>? errors,
+  }) : errors = errors ?? [];
+}
+
 /// Uploads locally-created or locally-modified entities to the backend.
 ///
 /// Each `uploadLocal*` method accepts a list of already-synced IDs (from
 /// [SyncDownloader]) so that only truly missing entities are pushed.
+/// HTTP calls are wrapped in [RetryHelper] for transient-failure resilience.
 class SyncUploader {
   final ApiProvider _apiProvider;
   final Token _token;
@@ -41,146 +56,267 @@ class SyncUploader {
   // ── Batch upload (missing-only) ───────────────────────────────
 
   /// Upload local artefacts that don't exist on backend.
-  Future<void> uploadLocalArtefacts(List<String> syncedIds) async {
+  Future<UploadResult> uploadLocalArtefacts(List<String> syncedIds) async {
+    final stats = EntitySyncStats(entityType: 'artefact');
+    final List<SyncError> errors = [];
     try {
       final userId = _userInfo.userId;
-      if (userId == null) return;
+      if (userId == null) {
+        return UploadResult(stats: stats, errors: errors);
+      }
 
       final localArtefacts = await _artefactRepo.getByUserId(userId);
       for (final artefact in localArtefacts) {
-        if (syncedIds.contains(artefact.artefactId)) continue;
-        final backendId = await _uploadArtefact(artefact);
-        if (backendId != null) syncedIds.add(backendId);
+        if (syncedIds.contains(artefact.artefactId)) {
+          stats.skipped++;
+          continue;
+        }
+        try {
+          final backendId = await _uploadArtefact(artefact);
+          if (backendId != null) {
+            syncedIds.add(backendId);
+            stats.succeeded++;
+          } else {
+            stats.failed++;
+            errors.add(SyncError(
+              entityType: 'artefact',
+              entityId: artefact.artefactId,
+              message: 'Upload returned null ID',
+            ));
+          }
+        } catch (e) {
+          stats.failed++;
+          errors.add(SyncError(
+            entityType: 'artefact',
+            entityId: artefact.artefactId,
+            message: e.toString(),
+          ));
+        }
       }
     } catch (e) {
-      _log.info('[SYNC] ERROR uploading local artefacts: $e');
+      _log.warning('[SYNC] ERROR uploading local artefacts: $e');
+      errors.add(SyncError(entityType: 'artefact', message: e.toString()));
     }
+    return UploadResult(stats: stats, errors: errors);
   }
 
   /// Upload local categories that don't exist on backend.
-  Future<void> uploadLocalCategories(List<String> syncedIds) async {
+  Future<UploadResult> uploadLocalCategories(List<String> syncedIds) async {
+    final stats = EntitySyncStats(entityType: 'category');
+    final List<SyncError> errors = [];
     try {
       final userId = _userInfo.userId;
-      if (userId == null) return;
+      if (userId == null) {
+        return UploadResult(stats: stats, errors: errors);
+      }
 
       final localCategories = await _categoryRepo.getByUserId(userId);
       for (final category in localCategories) {
-        if (syncedIds.contains(category.categoryId)) continue;
-        await _uploadCategory(category);
+        if (syncedIds.contains(category.categoryId)) {
+          stats.skipped++;
+          continue;
+        }
+        try {
+          final success = await _uploadCategory(category);
+          if (success) {
+            stats.succeeded++;
+          } else {
+            stats.failed++;
+            errors.add(SyncError(
+              entityType: 'category',
+              entityId: category.categoryId,
+              message: 'Upload failed',
+            ));
+          }
+        } catch (e) {
+          stats.failed++;
+          errors.add(SyncError(
+            entityType: 'category',
+            entityId: category.categoryId,
+            message: e.toString(),
+          ));
+        }
       }
     } catch (e) {
-      _log.info('[SYNC] ERROR uploading local categories: $e');
+      _log.warning('[SYNC] ERROR uploading local categories: $e');
+      errors.add(SyncError(entityType: 'category', message: e.toString()));
     }
+    return UploadResult(stats: stats, errors: errors);
   }
 
   /// Upload local boards that don't exist on backend.
-  Future<void> uploadLocalBoards(List<String> syncedIds) async {
+  Future<UploadResult> uploadLocalBoards(List<String> syncedIds) async {
+    final stats = EntitySyncStats(entityType: 'board');
+    final List<SyncError> errors = [];
     try {
       final userId = _userInfo.userId;
-      if (userId == null) return;
+      if (userId == null) {
+        return UploadResult(stats: stats, errors: errors);
+      }
 
       final localBoards = await _boardRepo.getByUserId(userId);
       for (final board in localBoards) {
-        if (syncedIds.contains(board.id)) continue;
-        await _uploadBoard(board);
+        if (syncedIds.contains(board.id)) {
+          stats.skipped++;
+          continue;
+        }
+        try {
+          final success = await _uploadBoard(board);
+          if (success) {
+            stats.succeeded++;
+          } else {
+            stats.failed++;
+            errors.add(SyncError(
+              entityType: 'board',
+              entityId: board.id,
+              message: 'Upload failed',
+            ));
+          }
+        } catch (e) {
+          stats.failed++;
+          errors.add(SyncError(
+            entityType: 'board',
+            entityId: board.id,
+            message: e.toString(),
+          ));
+        }
       }
     } catch (e) {
-      _log.info('[SYNC] ERROR uploading local boards: $e');
+      _log.warning('[SYNC] ERROR uploading local boards: $e');
+      errors.add(SyncError(entityType: 'board', message: e.toString()));
     }
+    return UploadResult(stats: stats, errors: errors);
   }
 
   // ── Single-entity uploads ─────────────────────────────────────
 
   Future<String?> _uploadArtefact(ArtefactDB artefact) async {
-    try {
-      final uri = Uri.parse('${_apiProvider.baseUrl}Artefacts');
-      final request = http.MultipartRequest('POST', uri);
-      request.headers['Authorization'] = 'Bearer ${_token.value}';
+    final uri = Uri.parse('${_apiProvider.baseUrl}Artefacts');
+    final request = http.MultipartRequest('POST', uri);
+    request.headers['Authorization'] = 'Bearer ${_token.value}';
 
-      request.fields['UserId'] = _userInfo.userId ?? '';
-      request.fields['ArtefactId'] = artefact.artefactId;
-      request.fields['Name'] = artefact.name ?? '';
-      request.fields['NameShown'] = (artefact.nameShown == 1).toString();
-      if (artefact.categoryId != null) {
-        request.fields['CategoryId'] = artefact.categoryId!;
+    request.fields['UserId'] = _userInfo.userId ?? '';
+    request.fields['ArtefactId'] = artefact.artefactId;
+    request.fields['Name'] = artefact.name ?? '';
+    request.fields['NameShown'] = (artefact.nameShown == 1).toString();
+    if (artefact.categoryId != null) {
+      request.fields['CategoryId'] = artefact.categoryId!;
+    }
+
+    if (artefact.imagePath != null) {
+      final imageFile = await _getLocalFile(
+          'Artefacts', artefact.imagePath!, _userInfo.userId ?? '');
+      if (imageFile != null && await imageFile.exists()) {
+        request.files
+            .add(await http.MultipartFile.fromPath('Image', imageFile.path));
       }
+    }
 
-      if (artefact.imagePath != null) {
-        final imageFile = await _getLocalFile(
-            'Artefacts', artefact.imagePath!, _userInfo.userId ?? '');
-        if (imageFile != null && await imageFile.exists()) {
-          request.files
-              .add(await http.MultipartFile.fromPath('Image', imageFile.path));
+    if (artefact.soundPath != null) {
+      final soundFile = await _getLocalFile(
+          'Sounds', artefact.soundPath!, _userInfo.userId ?? '');
+      if (soundFile != null && await soundFile.exists()) {
+        request.files
+            .add(await http.MultipartFile.fromPath('Sound', soundFile.path));
+      }
+    }
+
+    final result = await RetryHelper.run(
+      () async {
+        // Clone the request for each attempt (streams can only be read once)
+        final cloned = http.MultipartRequest('POST', uri);
+        cloned.headers.addAll(request.headers);
+        cloned.fields.addAll(request.fields);
+        for (final file in request.files) {
+          cloned.files.add(await http.MultipartFile.fromPath(
+            file.field,
+            file.filename!,
+          ));
         }
-      }
+        return await cloned.send();
+      },
+      label: 'POST artefact ${artefact.artefactId}',
+    );
 
-      if (artefact.soundPath != null) {
-        final soundFile = await _getLocalFile(
-            'Sounds', artefact.soundPath!, _userInfo.userId ?? '');
-        if (soundFile != null && await soundFile.exists()) {
-          request.files
-              .add(await http.MultipartFile.fromPath('Sound', soundFile.path));
-        }
-      }
-
-      final response = await request.send();
-      final responseBody = await response.stream.bytesToString();
-
-      if (response.statusCode == 200 || response.statusCode == 201) {
-        try {
-          final responseData = json.decode(responseBody);
-          return responseData['artefactId'] as String?;
-        } catch (e) {
-          _log.info(
-              '[SYNC] ERROR: Could not parse artefact ID from response: $e');
-        }
-      } else {
-        _log.info(
-            '[SYNC] ERROR: Failed to upload artefact ${artefact.artefactId}: ${response.statusCode}');
-        _log.info('[SYNC] Response: $responseBody');
-      }
-      return null;
-    } catch (e, stackTrace) {
-      _log.info('[SYNC] ERROR uploading artefact: $e');
-      _log.info('[SYNC] Stack trace: $stackTrace');
+    if (!result.succeeded) {
+      _log.warning(
+          '[SYNC] Failed to upload artefact ${artefact.artefactId} after retries');
       return null;
     }
-  }
 
-  Future<void> _uploadCategory(CategoryDB category) async {
-    try {
-      final uri = Uri.parse('${_apiProvider.baseUrl}Categories');
-      final request = http.MultipartRequest('POST', uri);
-      request.headers['Authorization'] = 'Bearer ${_token.value}';
+    final streamedResponse = result.value!;
+    final responseBody = await streamedResponse.stream.bytesToString();
 
-      request.fields['UserId'] = _userInfo.userId ?? '';
-      request.fields['CategoryId'] = category.categoryId;
-      request.fields['Name'] = category.name ?? '';
-
-      if (category.imagePath != null) {
-        final imageFile = await _getLocalFile(
-            'Categories', category.imagePath!, _userInfo.userId ?? '');
-        if (imageFile != null && await imageFile.exists()) {
-          request.files
-              .add(await http.MultipartFile.fromPath('Image', imageFile.path));
-        }
-      }
-
-      final response = await request.send();
-      if (response.statusCode != 200 && response.statusCode != 201) {
-        final responseBody = await response.stream.bytesToString();
+    if (streamedResponse.statusCode == 200 ||
+        streamedResponse.statusCode == 201) {
+      try {
+        final responseData = json.decode(responseBody);
+        return responseData['artefactId'] as String?;
+      } catch (e) {
         _log.info(
-            '[SYNC] ERROR: Failed to upload category ${category.categoryId}: ${response.statusCode}');
-        _log.info('[SYNC] Response: $responseBody');
+            '[SYNC] Could not parse artefact ID from response: $e');
       }
-    } catch (e) {
-      _log.info('[SYNC] ERROR uploading category: $e');
+    } else {
+      _log.info(
+          '[SYNC] Failed to upload artefact ${artefact.artefactId}: ${streamedResponse.statusCode}');
     }
+    return null;
   }
 
-  Future<void> _uploadBoard(SavedBoardDB board) async {
-    try {
-      final response = await _apiProvider.postAsJson(
+  /// Returns `true` on success.
+  Future<bool> _uploadCategory(CategoryDB category) async {
+    final uri = Uri.parse('${_apiProvider.baseUrl}Categories');
+
+    // Build the base request
+    final baseFields = <String, String>{
+      'UserId': _userInfo.userId ?? '',
+      'CategoryId': category.categoryId,
+      'Name': category.name ?? '',
+    };
+
+    File? imageFile;
+    if (category.imagePath != null) {
+      imageFile = await _getLocalFile(
+          'Categories', category.imagePath!, _userInfo.userId ?? '');
+      if (imageFile != null && !await imageFile.exists()) imageFile = null;
+    }
+
+    final result = await RetryHelper.run(
+      () async {
+        final request = http.MultipartRequest('POST', uri);
+        request.headers['Authorization'] = 'Bearer ${_token.value}';
+        request.fields.addAll(baseFields);
+        if (imageFile != null) {
+          request.files.add(
+              await http.MultipartFile.fromPath('Image', imageFile.path));
+        }
+        return await request.send();
+      },
+      label: 'POST category ${category.categoryId}',
+    );
+
+    if (!result.succeeded) {
+      _log.warning(
+          '[SYNC] Failed to upload category ${category.categoryId} after retries');
+      return false;
+    }
+
+    final response = result.value!;
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      return true;
+    }
+
+    final responseBody = await response.stream.bytesToString();
+    _log.info(
+        '[SYNC] Failed to upload category ${category.categoryId}: ${response.statusCode}');
+    _log.fine('[SYNC] Response: $responseBody');
+    return false;
+  }
+
+  /// Returns `true` on success.
+  Future<bool> _uploadBoard(SavedBoardDB board) async {
+    final result = await RetryHelper.runHttp(
+      () => _apiProvider.postAsJson(
         'Boards',
         headers: {
           'Authorization': 'Bearer ${_token.value}',
@@ -193,16 +329,19 @@ class SyncUploader {
           'artefactIds': board.artefactIds?.split(',') ?? [],
           'savedArtefactIds': board.savedArtefactIds?.split(',') ?? [],
         },
-      );
+      ),
+      label: 'POST board ${board.id}',
+    );
 
-      if (response == null ||
-          (response.statusCode != 200 && response.statusCode != 201)) {
-        _log.info(
-            '[SYNC] ERROR: Failed to upload board ${board.id}: ${response?.statusCode}');
-      }
-    } catch (e) {
-      _log.info('[SYNC] ERROR uploading board: $e');
+    final response = result.value;
+    if (response != null &&
+        (response.statusCode == 200 || response.statusCode == 201)) {
+      return true;
     }
+
+    _log.info(
+        '[SYNC] Failed to upload board ${board.id}: ${response?.statusCode}');
+    return false;
   }
 
   // ── Helpers ───────────────────────────────────────────────────

--- a/Frontend/vta_app/lib/src/utilities/retry_helper.dart
+++ b/Frontend/vta_app/lib/src/utilities/retry_helper.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+import 'dart:math';
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+
+final _log = Logger('RetryHelper');
+
+/// HTTP status codes that should never be retried because the request itself
+/// is the problem, not a transient server / network issue.
+const _nonRetryableStatusCodes = {400, 401, 403, 404, 405, 409, 422};
+
+/// Result of an operation executed through [RetryHelper].
+class RetryResult<T> {
+  /// The value returned by the operation, or `null` if all attempts failed.
+  final T? value;
+
+  /// Whether the operation ultimately succeeded.
+  final bool succeeded;
+
+  /// Number of attempts made (1 = succeeded on first try).
+  final int attempts;
+
+  /// The last error encountered, if the operation failed.
+  final Object? lastError;
+
+  const RetryResult._({
+    this.value,
+    required this.succeeded,
+    required this.attempts,
+    this.lastError,
+  });
+
+  factory RetryResult.success(T value, {int attempts = 1}) =>
+      RetryResult._(value: value, succeeded: true, attempts: attempts);
+
+  factory RetryResult.failure({required int attempts, Object? lastError}) =>
+      RetryResult._(succeeded: false, attempts: attempts, lastError: lastError);
+}
+
+/// Utility for retrying async operations with exponential backoff and jitter.
+///
+/// Usage:
+/// ```dart
+/// final result = await RetryHelper.run(
+///   () => apiProvider.fetchAsJson('Artefacts', headers: headers),
+///   label: 'fetchArtefacts',
+/// );
+/// if (result.succeeded) { /* use result.value */ }
+/// ```
+class RetryHelper {
+  /// Execute [operation] with retry + exponential backoff.
+  ///
+  /// * [maxAttempts] — total number of tries (including the first).
+  /// * [initialDelay] — base delay before the first retry (doubled each time).
+  /// * [shouldRetry] — optional predicate; when provided, only retry if it
+  ///   returns `true` for the caught exception. Defaults to retrying all.
+  /// * [label] — human-readable name shown in log messages.
+  static Future<RetryResult<T>> run<T>(
+    Future<T> Function() operation, {
+    int maxAttempts = 3,
+    Duration initialDelay = const Duration(milliseconds: 500),
+    bool Function(Object error)? shouldRetry,
+    String label = 'operation',
+  }) async {
+    final random = Random();
+    Object? lastError;
+
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        final result = await operation();
+        if (attempt > 1) {
+          _log.info('$label succeeded on attempt $attempt');
+        }
+        return RetryResult.success(result, attempts: attempt);
+      } catch (e) {
+        lastError = e;
+
+        if (shouldRetry != null && !shouldRetry(e)) {
+          _log.fine('$label failed with non-retryable error: $e');
+          return RetryResult.failure(attempts: attempt, lastError: e);
+        }
+
+        if (attempt == maxAttempts) {
+          _log.warning(
+              '$label failed after $maxAttempts attempts. Last error: $e');
+          return RetryResult.failure(attempts: attempt, lastError: e);
+        }
+
+        // Exponential backoff: delay * 2^(attempt-1) + random jitter
+        final backoff = initialDelay * pow(2, attempt - 1);
+        final jitter = Duration(
+          milliseconds: random.nextInt(backoff.inMilliseconds ~/ 2 + 1),
+        );
+        final totalDelay = backoff + jitter;
+
+        _log.info(
+          '$label attempt $attempt failed ($e). '
+          'Retrying in ${totalDelay.inMilliseconds}ms…',
+        );
+        await Future.delayed(totalDelay);
+      }
+    }
+
+    // Should never reach here, but just in case.
+    return RetryResult.failure(attempts: maxAttempts, lastError: lastError);
+  }
+
+  /// Convenience wrapper for HTTP calls that returns an [http.Response?].
+  ///
+  /// Automatically skips retry for non-retryable HTTP status codes (401, 403,
+  /// 404 etc.) by inspecting the response rather than relying on exceptions.
+  ///
+  /// Returns `null` only if all attempts produce null responses (e.g. network
+  /// errors caught by ApiProvider).
+  static Future<RetryResult<http.Response?>> runHttp(
+    Future<http.Response?> Function() operation, {
+    int maxAttempts = 3,
+    Duration initialDelay = const Duration(milliseconds: 500),
+    String label = 'HTTP request',
+  }) async {
+    final random = Random();
+    http.Response? lastResponse;
+    Object? lastError;
+
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        final response = await operation();
+        lastResponse = response;
+
+        if (response == null) {
+          // Network failure — ApiProvider returns null on exception
+          if (attempt == maxAttempts) {
+            _log.warning('$label: all $maxAttempts attempts returned null');
+            return RetryResult.failure(attempts: attempt);
+          }
+        } else if (response.statusCode >= 200 && response.statusCode < 300) {
+          if (attempt > 1) {
+            _log.info('$label succeeded on attempt $attempt');
+          }
+          return RetryResult.success(response, attempts: attempt);
+        } else if (_nonRetryableStatusCodes.contains(response.statusCode)) {
+          _log.fine(
+              '$label returned non-retryable status ${response.statusCode}');
+          return RetryResult.success(response, attempts: attempt);
+        } else {
+          // 5xx or other retryable status
+          if (attempt == maxAttempts) {
+            _log.warning(
+              '$label failed after $maxAttempts attempts. '
+              'Last status: ${response.statusCode}',
+            );
+            return RetryResult.success(response, attempts: attempt);
+          }
+        }
+      } catch (e) {
+        lastError = e;
+        if (attempt == maxAttempts) {
+          _log.warning(
+              '$label failed after $maxAttempts attempts. Last error: $e');
+          return RetryResult.failure(attempts: attempt, lastError: e);
+        }
+      }
+
+      // Backoff before next attempt
+      final backoff = initialDelay * pow(2, attempt - 1);
+      final jitter = Duration(
+        milliseconds: random.nextInt(backoff.inMilliseconds ~/ 2 + 1),
+      );
+      final totalDelay = backoff + jitter;
+
+      _log.info(
+        '$label attempt $attempt failed. '
+        'Retrying in ${totalDelay.inMilliseconds}ms…',
+      );
+      await Future.delayed(totalDelay);
+    }
+
+    // Fallback
+    if (lastResponse != null) {
+      return RetryResult.success(lastResponse, attempts: maxAttempts);
+    }
+    return RetryResult.failure(attempts: maxAttempts, lastError: lastError);
+  }
+}

--- a/improvementPlan.md
+++ b/improvementPlan.md
@@ -359,7 +359,7 @@ Use Dart SDK built-in `package:logging`. Create a shared `AppLogger` utility wit
 
 Add `logger.warning()`/`logger.severe()` calls inside all 28 empty `catch` blocks across 8 files. Dispose/cleanup catches → `logger.fine()`. Silenced real errors → `logger.severe()`.
 
-### 4.4 Add sync retry logic and transaction safety ⬜
+### 4.4 Add sync retry logic and transaction safety ✅
 
 Create a `RetryHelper` utility with exponential backoff for HTTP calls. Apply in `sync_downloader.dart` and `sync_uploader.dart`. Wrap per-entity-type sync in SQLite batch transactions. Change `syncFromServer` return type from `bool` to a `SyncResult` with error details.
 


### PR DESCRIPTION
## Summary

Implements Phase 4.4 of the improvement roadmap — sync retry logic, SQLite transaction safety, and structured sync results.

### Changes

**New: `RetryHelper` utility** (`lib/src/utilities/retry_helper.dart`)
- Generic `run<T>()` for any async operation with retry
- HTTP-specific `runHttp()` that inspects status codes before retrying
- Exponential backoff with jitter (base 500ms, doubles per attempt)
- Non-retryable status codes: 400, 401, 403, 404, 405, 409, 422
- Configurable max attempts (default 3)
- Returns `RetryResult<T>` with value, success flag, and attempt count

**New: `SyncResult` model** (added to `sync_models.dart`)
- `EntitySyncStats`: per-entity-type succeeded/failed/skipped counts
- `SyncError`: detailed error record with entity type, ID, message, timestamp
- `SyncResult`: aggregated result replacing `bool` return from `syncFromServer()`
  - download/upload stats maps, error list, timing, `success`/`partial` getters
  - `SyncResult.aborted()` factory for early-exit cases

**SyncDownloader** — retry + transactions + stats
- HTTP list-fetches wrapped in `RetryHelper.runHttp()`
- Asset downloads (images, sounds) wrapped in `RetryHelper.run()`
- All DB writes batched inside `db.transaction()` per entity type
- Returns `DownloadResult` with synced IDs + `EntitySyncStats` + errors
- Assets downloaded before transaction (network I/O outside txn scope)

**SyncUploader** — retry + stats
- Multipart uploads wrapped in `RetryHelper.run()`
- Board uploads use `RetryHelper.runHttp()` via ApiProvider
- Returns `UploadResult` with `EntitySyncStats` + errors
- Per-entity error tracking (was previously swallowed silently)

**SyncService** — structured return type
- `syncFromServer()` returns `SyncResult` instead of `bool`
- Aggregates all download/upload stats and errors
- `autoSync()` also returns `SyncResult`

**SyncTimer** — exponential backoff on failures
- Tracks consecutive failure count
- Interval grows: 30s → 60s → 120s → … → max 5min
- Resets to default on success
- Uses `Timer()` instead of `Timer.periodic()` for dynamic intervals

### Testing
- `flutter analyze`: 0 errors in modified files
- `flutter test`: 13/13 pass
- `dotnet build`: 0 errors

### Files changed (7)
- `+` `lib/src/utilities/retry_helper.dart`
- `~` `lib/src/services/sync_downloader.dart`
- `~` `lib/src/services/sync_uploader.dart`
- `~` `lib/src/services/sync_service.dart`
- `~` `lib/src/services/sync_timer.dart`
- `~` `lib/src/services/sync_models.dart`
- `~` `improvementPlan.md`