### PR TITLE
docs: update developer documentation for Phases 1-4

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,9 @@ These are the things that will break your work if you get them wrong:
 - **DB-first, no migrations**: `mysql_schema.sql` is the schema source of truth. Models are scaffolded via `dotnet ef dbcontext scaffold` (Pomelo). Never add EF migrations.
 - **Backend service layer**: Controllers delegate business logic to service classes in `VTA.API/Services/` (e.g. `ITtsService`, `IRelationService`, `IUserService`). Services inject `VTAContext` and are registered as `AddScoped` in `Program.cs`. Controllers handle HTTP concerns only (routing, model binding, auth, status codes).
 - **DTO mapping**: Static `DtoConverter` class, not AutoMapper.
-- **Flutter API returns**: `ApiProvider` returns `Response?` (null on failure). Callers must null-check AND verify `response.isOk`.
+- **Flutter API returns**: `ApiProvider` returns `Response?` (null on failure). Callers must null-check AND verify `response.isOk`. Sync callers wrap API calls in `RetryHelper` for transient-failure resilience.
+- **Flutter logging**: Never use `print()` or `debugPrint()`. Use `package:logging` with a file-scoped logger: `final _log = Logger('ClassName');`. `AppLogger.init()` is called once in `main.dart`.
+- **Sync return types**: Sync methods return `SyncResult` (not `bool`). Use its `success`, `partial`, `totalFailed` getters to decide next action.
 - **SignalR method names**: Hub method names and Flutter client callback names must match exactly (string-based, e.g. `"ArtifactAdded"`).
 - **SignalR package**: Flutter uses `signalr_netcore`, not the official Microsoft package.
 - **Localization**: New user-facing strings must use ARB keys (`l10n.yaml`), not hardcoded strings.

--- a/Frontend/vta_app/CLAUDE-flutter.md
+++ b/Frontend/vta_app/CLAUDE-flutter.md
@@ -12,25 +12,36 @@ Frontend/vta_app/lib/
 │   ├── models/                  # Client-side domain models
 │   ├── modelsDTOs/              # API data transfer objects
 │   ├── database/                # Local SQLite database layer
-│   │   ├── models/              # SQLite entity models
+│   │   ├── models/              # SQLite entity models (*DB classes with toMap/fromMap)
 │   │   ├── repositories/        # Repository pattern for DB access
 │   │   ├── mappers/             # DTO ↔ DB model mappers
-│   │   ├── database.dart        # DB initialization
-│   │   ├── database_helper.dart # DB operations
+│   │   ├── database.dart        # Barrel export for all DB types
+│   │   ├── database_helper.dart # Singleton DB instance + schema (version 2)
 │   │   └── database_debug_helper.dart
-│   ├── services/                # Backend communication + real-time
-│   │   ├── sync_service.dart        # Offline sync orchestration
-│   │   ├── sync_timer.dart          # Periodic sync scheduling
+│   ├── services/                # Backend communication + sync + real-time
+│   │   ├── sync_service.dart        # Thin orchestrator: download → upload per entity type
+│   │   ├── sync_downloader.dart     # Server → local sync (RetryHelper + SQLite transactions)
+│   │   ├── sync_uploader.dart       # Local → server sync (RetryHelper + error tracking)
+│   │   ├── sync_change_detector.dart# Query API/local DB for change records
+│   │   ├── sync_models.dart         # SyncResult, EntitySyncStats, SyncError, FileChangeRecord
+│   │   ├── sync_timer.dart          # Periodic sync with exponential backoff on failure
 │   │   ├── remote_sync_service.dart # Remote data sync
-│   │   ├── signalr_service.dart     # SignalR hub connection
-│   │   ├── webrtc_service.dart      # WebRTC peer connections
-│   │   ├── call_manager.dart        # Audio call management
-│   │   ├── video_call_manager.dart  # Video call management
+│   │   ├── remote_board_sync_sender.dart   # Outbound SignalR board deltas
+│   │   ├── remote_board_sync_receiver.dart # Inbound SignalR board event handlers
+│   │   ├── signalr_service.dart     # SignalR facade (session/board/WebRTC invoke wrappers)
+│   │   ├── signalr_connection_manager.dart # Hub connection lifecycle
+│   │   ├── signalr_event_router.dart      # All .on() handler registrations
+│   │   ├── online_status_tracker.dart     # Track/refresh/query online users
 │   │   ├── board_layout_service.dart
 │   │   ├── relation_service.dart
+│   │   ├── call_manager.dart        # Audio call management
+│   │   ├── video_call_manager.dart  # Video call management
+│   │   ├── webrtc_service.dart      # WebRTC peer connections
 │   │   └── notification_service.dart
 │   ├── utilities/
-│   │   ├── api/                 # HTTP client (ApiProvider)
+│   │   ├── api/                 # HTTP client (ApiProvider — returns Response?, null on failure)
+│   │   ├── retry_helper.dart    # Exponential backoff + jitter for HTTP/async ops
+│   │   ├── app_logger.dart      # AppLogger.init() — configures package:logging
 │   │   ├── audio/               # Audio recording/playback
 │   │   ├── config/              # App configuration
 │   │   ├── data/                # DataRepository, ImageData
@@ -63,6 +74,7 @@ flutter run                      # Run on connected device/emulator
 flutter run -d chrome             # Run on web (for quick testing)
 flutter test                     # Unit tests
 flutter test integration_test/    # Integration tests (needs device)
+flutter analyze                  # Static analysis
 ```
 
 ## Key Dependencies
@@ -74,6 +86,7 @@ flutter test integration_test/    # Integration tests (needs device)
 | `flutter_webrtc` | WebRTC for video calling |
 | `sqflite` | Local SQLite database |
 | `http` | HTTP client for REST API |
+| `logging` | Structured logging (replaces print/debugPrint) |
 | `just_audio` | Audio playback |
 | `record` | Audio recording |
 | `camera` | Camera access |
@@ -83,9 +96,86 @@ flutter test integration_test/    # Integration tests (needs device)
 ## Architecture Pattern
 
 - **MVC-ish**: Controllers (ChangeNotifiers) → Models → Services → API
-- **Offline-first**: Local SQLite DB with sync to backend MySQL
+- **Offline-first**: Local SQLite DB with bidirectional sync to backend MySQL
 - **Provider tree**: Controllers provided at app root, consumed by widgets
 - **Singletons**: Token and UserInfo stored globally for auth state
+- **Service locator**: `GetIt` for DI — services accept optional constructor params, fall back to `GetIt.instance.get<T>()`
+
+## Logging Convention
+
+All files use `package:logging` with a file-scoped named logger:
+
+```dart
+import 'package:logging/logging.dart';
+final _log = Logger('ClassName');
+
+// Usage:
+_log.info('message');       // normal operation
+_log.warning('message');    // unexpected but recoverable
+_log.severe('message');     // errors
+_log.fine('message');       // debug / dispose / cleanup
+```
+
+`AppLogger.init()` is called once in `main.dart` to configure the root logger (hierarchical, outputs to console in debug builds).
+
+**Never use `print()` or `debugPrint()`** — the codebase was fully migrated to `package:logging`.
+
+## Sync Architecture
+
+The sync subsystem is split into focused classes:
+
+```
+SyncTimer (periodic trigger, exponential backoff on failure)
+  └── SyncService (thin orchestrator)
+        ├── SyncDownloader.downloadArtefacts/Categories/Boards()
+        │     → RetryHelper.runHttp() for API calls
+        │     → RetryHelper.run() for asset downloads
+        │     → SQLite db.transaction() for batch writes
+        │     → Returns DownloadResult { syncedIds, EntitySyncStats, errors }
+        ├── SyncUploader.uploadLocalArtefacts/Categories/Boards()
+        │     → RetryHelper.run() for multipart uploads
+        │     → RetryHelper.runHttp() for JSON posts
+        │     → Returns UploadResult { EntitySyncStats, errors }
+        └── SyncChangeDetector (remote/local change queries)
+```
+
+**Key types:**
+- `SyncResult` — aggregated result of a full sync pass (replaces old `bool` return). Has `success`, `partial`, `totalDownloaded`, `totalUploaded`, `totalFailed` getters.
+- `EntitySyncStats` — per-entity-type succeeded/failed/skipped counts.
+- `SyncError` — detailed error record with entity type, ID, message, timestamp.
+- `DownloadResult` / `UploadResult` — per-pass results with IDs + stats + errors.
+
+**RetryHelper** (`lib/src/utilities/retry_helper.dart`):
+- `RetryHelper.run<T>()` — generic async retry with exponential backoff + jitter
+- `RetryHelper.runHttp()` — HTTP-aware variant that skips retry for 401/403/404
+- Default: 3 attempts, 500ms initial delay, doubles per attempt
+- Returns `RetryResult<T>` with value, success flag, and attempt count
+
+**SyncTimer backoff:**
+- Default interval: 30 seconds
+- On consecutive failures: 30s → 60s → 120s → … → max 5 minutes
+- Resets to default on first successful sync
+
+## SignalR Architecture
+
+The SignalR client is split into focused classes:
+
+```
+SignalRService (public facade — session/board/WebRTC invoke wrappers)
+  ├── SignalRConnectionManager (connect/disconnect/reconnect lifecycle)
+  ├── SignalREventRouter (all .on() callback registrations)
+  └── OnlineStatusTracker (online user list management)
+```
+
+**Critical**: Hub method names and Flutter callback names must match exactly (string-based). The Flutter client uses `signalr_netcore`, NOT the official Microsoft package.
+
+## Database
+
+- **Engine**: `sqflite` with singleton `DatabaseHelper.instance`
+- **Schema version**: 2 (7 tables: user, category, artefact, saved_board, saved_artefact, session_meta, sync_metadata)
+- **Repository pattern**: One repository per table (e.g. `ArtefactRepository`, `SavedBoardRepository`)
+- **Transactions**: Sync downloads use `db.transaction((txn) => ...)` for batch writes
+- **Models**: `*DB` classes with `toMap()` / `fromMap()` for SQLite serialization
 
 ## Configuration
 
@@ -94,3 +184,11 @@ App settings loaded from `assets/cfg/app_settings.json` (gitignored). Contains:
 - SyncService URL
 - ElevenLabs API key
 - TURN server credentials
+
+## API Client
+
+`ApiProvider` wraps `package:http`:
+- Methods: `fetchAsJson`, `postAsJson`, `patchAsJson`, `putAsJson`, `delete`, `sendAsMultiPart`
+- **Returns `Response?`** — returns `null` on exception (no retry at this level)
+- Callers must null-check AND verify `response.statusCode`
+- Sync callers wrap ApiProvider calls in `RetryHelper` for transient failure resilience

--- a/improvementPlan.md
+++ b/improvementPlan.md
@@ -336,7 +336,7 @@ Session API, board sync API, and WebRTC relay methods stay in `SignalRService` (
 
 ## Phase 4 — Reliability & Observability
 
-### 4.1 Replace `Console.WriteLine` with `ILogger` in backend (91 occurrences) ⬜
+### 4.1 Replace `Console.WriteLine` with `ILogger` in backend (91 occurrences) ✅
 
 Inject `ILogger<T>` into the 7 files that use `Console.Write*`. Map each call to the appropriate log level (`LogInformation`, `LogWarning`, `LogError`). Wire up the 3 services that already have `ILogger` injected but don't use it.
 
@@ -351,11 +351,11 @@ Inject `ILogger<T>` into the 7 files that use `Console.Write*`. Map each call to
 | `DbContextExtensions.cs` | 1 | |
 | Unused `ILogger` fields | 3 services | `PresenceService`, `SessionService`, `BoardSyncRelay` — injected but never called |
 
-### 4.2 Replace `print()`/`debugPrint()` with `package:logging` in Flutter (334+ calls) ⬜
+### 4.2 Replace `print()`/`debugPrint()` with `package:logging` in Flutter (334+ calls) ✅
 
 Use Dart SDK built-in `package:logging`. Create a shared `AppLogger` utility with named loggers per file. Replace all `print()`/`debugPrint()` calls. Remove `// ignore_for_file: avoid_print` directives.
 
-### 4.3 Fix 28 empty catch blocks in Flutter ⬜
+### 4.3 Fix 28 empty catch blocks in Flutter ✅
 
 Add `logger.warning()`/`logger.severe()` calls inside all 28 empty `catch` blocks across 8 files. Dispose/cleanup catches → `logger.fine()`. Silenced real errors → `logger.severe()`.
 


### PR DESCRIPTION
Updates all developer-facing documentation to reflect Phases 1–4 changes:

- **CLAUDE-flutter.md**: Full rewrite — complete directory tree (all 19 services, utilities), sync architecture (SyncResult, RetryHelper, SyncTimer backoff), logging convention, SignalR split, database layer, API client docs
- **copilot-instructions.md**: Added Flutter logging convention, sync return types (SyncResult), RetryHelper usage in sync callers
- **improvementPlan.md**: Status table updated with Phase 4 sub-items and PR numbers (#285, #286)