### PR TITLE
feat: add backend pagination to list endpoints (Phase 4.5)

### DIFF
--- a/Backend/VTA.API/Controllers/AdminController.cs
+++ b/Backend/VTA.API/Controllers/AdminController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using VTA.API.DTOs;
+using VTA.API.Extensions;
 using VTA.API.Services;
 using VTA.Data.DbContexts;
 using VTA.Data.Models;
@@ -25,39 +26,57 @@ public class AdminController : ControllerBase
     }
 
     [HttpGet("caregivers")]
-    public async Task<ActionResult<IEnumerable<UserGetDTO>>> GetCaregivers()
+    public async Task<ActionResult> GetCaregivers([FromQuery] int? skip, [FromQuery] int? take)
     {
-        var caregivers = await _context.Users
+        var query = _context.Users
             .Where(u => u.Role == UserRole.Caregiver)
             .AsNoTracking()
-            .ToListAsync();
+            .OrderBy(u => u.Username);
 
-        var caregiversDto = caregivers.Select(DTOConverter.MapUserToUserGetDTO).ToList();
-        return Ok(caregiversDto);
+        var page = await query.ToPaginatedAsync(skip, take);
+        return Ok(new PaginatedResponse<UserGetDTO>
+        {
+            Items = page.Items.Select(DTOConverter.MapUserToUserGetDTO).ToList(),
+            TotalCount = page.TotalCount,
+            Skip = page.Skip,
+            Take = page.Take
+        });
     }
 
     [HttpGet("children")]
-    public async Task<ActionResult<IEnumerable<UserGetDTO>>> GetChildren()
+    public async Task<ActionResult> GetChildren([FromQuery] int? skip, [FromQuery] int? take)
     {
-        var children = await _context.Users
+        var query = _context.Users
             .Where(u => u.Role == UserRole.Child)
             .AsNoTracking()
-            .ToListAsync();
+            .OrderBy(u => u.Username);
 
-        var childrenDto = children.Select(DTOConverter.MapUserToUserGetDTO).ToList();
-        return Ok(childrenDto);
+        var page = await query.ToPaginatedAsync(skip, take);
+        return Ok(new PaginatedResponse<UserGetDTO>
+        {
+            Items = page.Items.Select(DTOConverter.MapUserToUserGetDTO).ToList(),
+            TotalCount = page.TotalCount,
+            Skip = page.Skip,
+            Take = page.Take
+        });
     }
 
     [HttpGet("admins")]
-    public async Task<ActionResult<IEnumerable<UserGetDTO>>> GetAdmins()
+    public async Task<ActionResult> GetAdmins([FromQuery] int? skip, [FromQuery] int? take)
     {
-        var admins = await _context.Users
+        var query = _context.Users
             .Where(u => u.Role == UserRole.Admin)
             .AsNoTracking()
-            .ToListAsync();
+            .OrderBy(u => u.Username);
 
-        var adminsDto = admins.Select(DTOConverter.MapUserToUserGetDTO).ToList();
-        return Ok(adminsDto);
+        var page = await query.ToPaginatedAsync(skip, take);
+        return Ok(new PaginatedResponse<UserGetDTO>
+        {
+            Items = page.Items.Select(DTOConverter.MapUserToUserGetDTO).ToList(),
+            TotalCount = page.TotalCount,
+            Skip = page.Skip,
+            Take = page.Take
+        });
     }
 
     [HttpPost("admins")]
@@ -97,9 +116,9 @@ public class AdminController : ControllerBase
     }
 
     [HttpGet("pairings")]
-    public async Task<ActionResult<IEnumerable<PairingDTO>>> GetPairings()
+    public async Task<ActionResult<IEnumerable<PairingDTO>>> GetPairings([FromQuery] int? skip, [FromQuery] int? take)
     {
-        var pairings = await _relationService.GetAllPairingsAsync(activeOnly: true);
+        var pairings = await _relationService.GetAllPairingsAsync(activeOnly: true, skip: skip, take: take);
         return Ok(pairings);
     }
 

--- a/Backend/VTA.API/Controllers/ArtefactsController.cs
+++ b/Backend/VTA.API/Controllers/ArtefactsController.cs
@@ -17,14 +17,16 @@ public class ArtefactsController(VTAContext context, ITtsService ttsService, IAr
     /// <summary>
     /// Gets all artefacts that a user owns
     /// </summary>
+    /// <param name="skip">Number of items to skip (pagination)</param>
+    /// <param name="take">Number of items to return (pagination, default 50)</param>
     /// <returns>An IEnumerable of artefacts</returns>
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<ArtefactGetDTO>>> GetArtefacts()
+    public async Task<ActionResult<IEnumerable<ArtefactGetDTO>>> GetArtefacts([FromQuery] int? skip, [FromQuery] int? take)
     {
         var userId = User.FindFirst("id")?.Value;
         if (string.IsNullOrEmpty(userId)) return Unauthorized();
 
-        var artefacts = await artefactService.GetArtefactsForUserAsync(userId);
+        var artefacts = await artefactService.GetArtefactsForUserAsync(userId, skip, take);
 
         var artefactGetDTOs = artefacts
             .Select(artefact => DTOConverter.MapArtefactToArtefactGetDTO(artefact, Request.Scheme, Request.Host.ToString()))

--- a/Backend/VTA.API/Controllers/BoardsController.cs
+++ b/Backend/VTA.API/Controllers/BoardsController.cs
@@ -30,14 +30,16 @@ public class BoardsController : ControllerBase
   /// <summary>
   /// Gets all boards that the authenticated user owns
   /// </summary>
+  /// <param name="skip">Number of items to skip (pagination)</param>
+  /// <param name="take">Number of items to return (pagination, default 50)</param>
   /// <returns>A collection of boards with their saved artefacts</returns>
   [HttpGet]
-  public async Task<ActionResult<IEnumerable<BoardGetDTO>>> GetBoards()
+  public async Task<ActionResult<IEnumerable<BoardGetDTO>>> GetBoards([FromQuery] int? skip, [FromQuery] int? take)
   {
     var userId = User.FindFirst("id")?.Value;
     if (string.IsNullOrEmpty(userId)) return Unauthorized();
 
-    var boards = await _boardService.GetBoardsForUserAsync(userId);
+    var boards = await _boardService.GetBoardsForUserAsync(userId, skip, take);
 
     var boardDTOs = boards.Select(board => new BoardGetDTO
     {
@@ -55,14 +57,16 @@ public class BoardsController : ControllerBase
   /// <summary>
   /// Gets a lightweight list of board IDs, names, and thumbnails for the authenticated user
   /// </summary>
+  /// <param name="skip">Number of items to skip (pagination)</param>
+  /// <param name="take">Number of items to return (pagination, default 50)</param>
   /// <returns>A collection of minimal board information</returns>
   [HttpGet("list")]
-  public async Task<ActionResult<IEnumerable<BoardListItemDTO>>> GetBoardsList()
+  public async Task<ActionResult<IEnumerable<BoardListItemDTO>>> GetBoardsList([FromQuery] int? skip, [FromQuery] int? take)
   {
     var userId = User.FindFirst("id")?.Value;
     if (string.IsNullOrEmpty(userId)) return Unauthorized();
 
-    var boards = await _boardService.GetBoardListAsync(userId);
+    var boards = await _boardService.GetBoardListAsync(userId, skip, take);
 
     var boardListItems = boards.Select(board => new BoardListItemDTO
     {

--- a/Backend/VTA.API/Controllers/CategoriesController.cs
+++ b/Backend/VTA.API/Controllers/CategoriesController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using VTA.API.DTOs;
+using VTA.API.Extensions;
 using VTA.API.Utilities;
 using VTA.Data.DbContexts;
 using VTA.Data.Models;
@@ -20,27 +21,31 @@ public class CategoriesController(VTAContext context, ILogger<CategoriesControll
     /// <summary>
     /// Gets all categories (and artefacts within them) that a user owns
     /// </summary>
-    /// <returns>An IEnumerable of Categories</returns>
+    /// <param name="skip">Number of items to skip (pagination)</param>
+    /// <param name="take">Number of items to return (pagination, default 50)</param>
+    /// <returns>A paginated list of Categories</returns>
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<CategoryGetDTO>>> GetCategories()
+    public async Task<ActionResult> GetCategories([FromQuery] int? skip, [FromQuery] int? take)
     {
         var userId = User.FindFirst("id")?.Value;
 
-        List<Category>? categories = await context.Categories
+        var query = context.Categories
             .AsNoTracking()
             .Where(c => c.UserId == userId)
             .Include(c => c.Artefacts)
-            .ToListAsync();
-        if (categories == null)
+            .OrderBy(c => c.CategoryIndex);
+
+        var page = await query.ToPaginatedAsync(skip, take);
+
+        return Ok(new PaginatedResponse<CategoryGetDTO>
         {
-            return NotFound();
-        }
-
-        var categoryGetDTOs = categories
-            .Select(category => DTOConverter.MapCategoryToCategoryGetDTO(category, Request.Scheme, Request.Host.ToString()))
-            .ToList();
-
-        return categoryGetDTOs;
+            Items = page.Items
+                .Select(category => DTOConverter.MapCategoryToCategoryGetDTO(category, Request.Scheme, Request.Host.ToString()))
+                .ToList(),
+            TotalCount = page.TotalCount,
+            Skip = page.Skip,
+            Take = page.Take
+        });
     }
 
     // GET: api/Categories/5

--- a/Backend/VTA.API/Controllers/RelationController.cs
+++ b/Backend/VTA.API/Controllers/RelationController.cs
@@ -27,9 +27,9 @@ public class RelationController : ControllerBase
     /// Get all pairings
     /// </summary>
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<PairingDTO>>> GetPairings()
+    public async Task<ActionResult<IEnumerable<PairingDTO>>> GetPairings([FromQuery] int? skip, [FromQuery] int? take)
     {
-        var pairings = await _relationService.GetAllPairingsAsync();
+        var pairings = await _relationService.GetAllPairingsAsync(skip: skip, take: take);
         return Ok(pairings);
     }
 
@@ -37,9 +37,9 @@ public class RelationController : ControllerBase
     /// Get pairings for a specific caregiver
     /// </summary>
     [HttpGet("caregiver/{caregiverId}")]
-    public async Task<ActionResult<IEnumerable<PairingDTO>>> GetPairingsForCaregiver(string caregiverId)
+    public async Task<ActionResult<IEnumerable<PairingDTO>>> GetPairingsForCaregiver(string caregiverId, [FromQuery] int? skip, [FromQuery] int? take)
     {
-        var pairings = await _relationService.GetPairingsForCaregiverAsync(caregiverId);
+        var pairings = await _relationService.GetPairingsForCaregiverAsync(caregiverId, skip, take);
         return Ok(pairings);
     }
 

--- a/Backend/VTA.API/Controllers/UsersController.cs
+++ b/Backend/VTA.API/Controllers/UsersController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using VTA.API.DTOs;
+using VTA.API.Extensions;
 using VTA.API.Services;
 using VTA.Data.DbContexts;
 using VTA.Data.Models;
@@ -69,24 +70,24 @@ public class UsersController(VTAContext context, IUserService userService, IRela
 
     // GET: api/Users
     /// <summary>
-    /// Get all users in the DB (I thought i had removed this?)
+    /// Get all users in the DB
     /// </summary>
-    /// <remarks>
-    /// This could be alted to get all users tied to a parent/pedagogue/teacher
-    /// </remarks>
-    /// <returns>A list of users</returns>
+    /// <returns>A paginated list of users</returns>
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<UserGetDTO>>> GetUsers()
+    public async Task<ActionResult> GetUsers([FromQuery] int? skip, [FromQuery] int? take)
     {
-        List<User> users = await context.Users
+        var query = context.Users
             .AsNoTracking()
-            .ToListAsync();
+            .OrderBy(u => u.Username);
 
-        var userGetDTOs = users
-            .Select(user => DTOConverter.MapUserToUserGetDTO(user))
-            .ToList();
-
-        return userGetDTOs;
+        var page = await query.ToPaginatedAsync(skip, take);
+        return Ok(new PaginatedResponse<UserGetDTO>
+        {
+            Items = page.Items.Select(DTOConverter.MapUserToUserGetDTO).ToList(),
+            TotalCount = page.TotalCount,
+            Skip = page.Skip,
+            Take = page.Take
+        });
     }
 
     // GET: api/Users/related-contacts

--- a/Backend/VTA.API/DTOs/PaginationDTO.cs
+++ b/Backend/VTA.API/DTOs/PaginationDTO.cs
@@ -1,0 +1,22 @@
+namespace VTA.API.DTOs;
+
+/// <summary>
+/// Generic wrapper for paginated list responses.
+/// All list endpoints return this shape when <c>skip</c>/<c>take</c> are supplied.
+/// Backward-compatible: when no pagination params are given, <c>Items</c>
+/// contains the full result set and <c>TotalCount</c> equals <c>Items.Count</c>.
+/// </summary>
+public class PaginatedResponse<T>
+{
+    /// <summary>The page of results.</summary>
+    public required List<T> Items { get; set; }
+
+    /// <summary>Total number of items matching the query (before skip/take).</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Number of items skipped (0-based offset).</summary>
+    public int Skip { get; set; }
+
+    /// <summary>Maximum items returned in this page.</summary>
+    public int Take { get; set; }
+}

--- a/Backend/VTA.API/Extensions/PaginationExtensions.cs
+++ b/Backend/VTA.API/Extensions/PaginationExtensions.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using VTA.API.DTOs;
+
+namespace VTA.API.Extensions;
+
+/// <summary>
+/// Reusable IQueryable extension for applying skip/take pagination
+/// and materializing the result into a <see cref="PaginatedResponse{T}"/>.
+/// </summary>
+public static class PaginationExtensions
+{
+    /// <summary>
+    /// Default page size when no take value is specified or take is &lt;= 0.
+    /// </summary>
+    public const int DefaultPageSize = 50;
+
+    /// <summary>
+    /// Maximum allowed page size to prevent abuse.
+    /// </summary>
+    public const int MaxPageSize = 200;
+
+    /// <summary>
+    /// Applies skip/take pagination to an <see cref="IQueryable{T}"/>,
+    /// counts the total matching rows, and returns a <see cref="PaginatedResponse{T}"/>.
+    /// </summary>
+    /// <param name="query">The source query (ordering should already be applied).</param>
+    /// <param name="skip">Number of items to skip (default 0).</param>
+    /// <param name="take">Number of items to take (default <see cref="DefaultPageSize"/>, max <see cref="MaxPageSize"/>).</param>
+    /// <returns>A paginated response with items, total count, and pagination metadata.</returns>
+    public static async Task<PaginatedResponse<T>> ToPaginatedAsync<T>(
+        this IQueryable<T> query,
+        int? skip = null,
+        int? take = null)
+    {
+        var resolvedSkip = Math.Max(skip ?? 0, 0);
+        var resolvedTake = Math.Clamp(take ?? DefaultPageSize, 1, MaxPageSize);
+
+        var totalCount = await query.CountAsync();
+
+        var items = await query
+            .Skip(resolvedSkip)
+            .Take(resolvedTake)
+            .ToListAsync();
+
+        return new PaginatedResponse<T>
+        {
+            Items = items,
+            TotalCount = totalCount,
+            Skip = resolvedSkip,
+            Take = resolvedTake
+        };
+    }
+}

--- a/Backend/VTA.API/Services/ArtefactService.cs
+++ b/Backend/VTA.API/Services/ArtefactService.cs
@@ -23,12 +23,21 @@ public class ArtefactService : IArtefactService
     }
 
     /// <inheritdoc />
-    public async Task<List<Artefact>> GetArtefactsForUserAsync(string userId)
+    public async Task<List<Artefact>> GetArtefactsForUserAsync(string userId, int? skip = null, int? take = null)
     {
-        return await _context.Artefacts
+        var query = _context.Artefacts
             .AsNoTracking()
             .Where(a => a.UserId == userId)
-            .ToListAsync();
+            .OrderBy(a => a.ArtefactIndex);
+
+        if (skip.HasValue || take.HasValue)
+        {
+            var resolvedSkip = Math.Max(skip ?? 0, 0);
+            var resolvedTake = Math.Clamp(take ?? 50, 1, 200);
+            return await query.Skip(resolvedSkip).Take(resolvedTake).ToListAsync();
+        }
+
+        return await query.ToListAsync();
     }
 
     /// <inheritdoc />

--- a/Backend/VTA.API/Services/BoardService.cs
+++ b/Backend/VTA.API/Services/BoardService.cs
@@ -24,23 +24,39 @@ public class BoardService : IBoardService
     }
 
     /// <inheritdoc />
-    public async Task<List<SavedBoard>> GetBoardsForUserAsync(string userId)
+    public async Task<List<SavedBoard>> GetBoardsForUserAsync(string userId, int? skip = null, int? take = null)
     {
-        return await _context.SavedBoards
+        var query = _context.SavedBoards
             .Where(b => b.UserId == userId)
             .Include(b => b.SavedArtefacts)
                 .ThenInclude(sa => sa.Artefact)
-            .OrderByDescending(b => b.ModifiedDate ?? b.CreatedDate)
-            .ToListAsync();
+            .OrderByDescending(b => b.ModifiedDate ?? b.CreatedDate);
+
+        if (skip.HasValue || take.HasValue)
+        {
+            var resolvedSkip = Math.Max(skip ?? 0, 0);
+            var resolvedTake = Math.Clamp(take ?? 50, 1, 200);
+            return await query.Skip(resolvedSkip).Take(resolvedTake).ToListAsync();
+        }
+
+        return await query.ToListAsync();
     }
 
     /// <inheritdoc />
-    public async Task<List<SavedBoard>> GetBoardListAsync(string userId)
+    public async Task<List<SavedBoard>> GetBoardListAsync(string userId, int? skip = null, int? take = null)
     {
-        return await _context.SavedBoards
+        var query = _context.SavedBoards
             .Where(b => b.UserId == userId)
-            .OrderByDescending(b => b.ModifiedDate ?? b.CreatedDate)
-            .ToListAsync();
+            .OrderByDescending(b => b.ModifiedDate ?? b.CreatedDate);
+
+        if (skip.HasValue || take.HasValue)
+        {
+            var resolvedSkip = Math.Max(skip ?? 0, 0);
+            var resolvedTake = Math.Clamp(take ?? 50, 1, 200);
+            return await query.Skip(resolvedSkip).Take(resolvedTake).ToListAsync();
+        }
+
+        return await query.ToListAsync();
     }
 
     /// <inheritdoc />

--- a/Backend/VTA.API/Services/IArtefactService.cs
+++ b/Backend/VTA.API/Services/IArtefactService.cs
@@ -12,8 +12,10 @@ public interface IArtefactService
 {
     /// <summary>
     /// Get all artefacts owned by the specified user.
+    /// When <paramref name="skip"/> and <paramref name="take"/> are provided,
+    /// returns a paginated subset.
     /// </summary>
-    Task<List<Artefact>> GetArtefactsForUserAsync(string userId);
+    Task<List<Artefact>> GetArtefactsForUserAsync(string userId, int? skip = null, int? take = null);
 
     /// <summary>
     /// Get a single artefact by ID, scoped to the specified user.

--- a/Backend/VTA.API/Services/IBoardService.cs
+++ b/Backend/VTA.API/Services/IBoardService.cs
@@ -12,13 +12,17 @@ public interface IBoardService
     /// <summary>
     /// Get all boards owned by the specified user, ordered by most-recently-modified.
     /// Includes SavedArtefact navigation data.
+    /// When <paramref name="skip"/> and <paramref name="take"/> are provided,
+    /// returns a paginated subset.
     /// </summary>
-    Task<List<SavedBoard>> GetBoardsForUserAsync(string userId);
+    Task<List<SavedBoard>> GetBoardsForUserAsync(string userId, int? skip = null, int? take = null);
 
     /// <summary>
     /// Get a lightweight list of boards (no artefact navigation) for listing UI.
+    /// When <paramref name="skip"/> and <paramref name="take"/> are provided,
+    /// returns a paginated subset.
     /// </summary>
-    Task<List<SavedBoard>> GetBoardListAsync(string userId);
+    Task<List<SavedBoard>> GetBoardListAsync(string userId, int? skip = null, int? take = null);
 
     /// <summary>
     /// Get a single board with all its saved artefacts (including nested Artefact entities).

--- a/Backend/VTA.API/Services/IRelationService.cs
+++ b/Backend/VTA.API/Services/IRelationService.cs
@@ -10,10 +10,10 @@ namespace VTA.API.Services;
 public interface IRelationService
 {
     /// <summary>Get all pairings, optionally filtering by active status.</summary>
-    Task<List<PairingDTO>> GetAllPairingsAsync(bool? activeOnly = null);
+    Task<List<PairingDTO>> GetAllPairingsAsync(bool? activeOnly = null, int? skip = null, int? take = null);
 
     /// <summary>Get pairings for a specific caregiver.</summary>
-    Task<List<PairingDTO>> GetPairingsForCaregiverAsync(string caregiverId);
+    Task<List<PairingDTO>> GetPairingsForCaregiverAsync(string caregiverId, int? skip = null, int? take = null);
 
     /// <summary>
     /// Get the related contacts for a user (children if caregiver, caregivers if child).

--- a/Backend/VTA.API/Services/RelationService.cs
+++ b/Backend/VTA.API/Services/RelationService.cs
@@ -20,7 +20,7 @@ public class RelationService : IRelationService
     }
 
     /// <inheritdoc />
-    public async Task<List<PairingDTO>> GetAllPairingsAsync(bool? activeOnly = null)
+    public async Task<List<PairingDTO>> GetAllPairingsAsync(bool? activeOnly = null, int? skip = null, int? take = null)
     {
         var query = _context.Relations
             .Include(p => p.Caregiver)
@@ -32,21 +32,37 @@ public class RelationService : IRelationService
             query = query.Where(p => p.IsActive);
         }
 
-        var pairings = await query.ToListAsync();
-        return pairings.Select(MapToPairingDTO).ToList();
+        if (skip.HasValue || take.HasValue)
+        {
+            var resolvedSkip = Math.Max(skip ?? 0, 0);
+            var resolvedTake = Math.Clamp(take ?? 50, 1, 200);
+            var pairings = await query.Skip(resolvedSkip).Take(resolvedTake).ToListAsync();
+            return pairings.Select(MapToPairingDTO).ToList();
+        }
+
+        var allPairings = await query.ToListAsync();
+        return allPairings.Select(MapToPairingDTO).ToList();
     }
 
     /// <inheritdoc />
-    public async Task<List<PairingDTO>> GetPairingsForCaregiverAsync(string caregiverId)
+    public async Task<List<PairingDTO>> GetPairingsForCaregiverAsync(string caregiverId, int? skip = null, int? take = null)
     {
-        var pairings = await _context.Relations
+        var query = _context.Relations
             .Include(p => p.Caregiver)
             .Include(p => p.Child)
             .Where(p => p.CaregiverId == caregiverId && p.IsActive)
-            .AsNoTracking()
-            .ToListAsync();
+            .AsNoTracking();
 
-        return pairings.Select(MapToPairingDTO).ToList();
+        if (skip.HasValue || take.HasValue)
+        {
+            var resolvedSkip = Math.Max(skip ?? 0, 0);
+            var resolvedTake = Math.Clamp(take ?? 50, 1, 200);
+            var pairings = await query.Skip(resolvedSkip).Take(resolvedTake).ToListAsync();
+            return pairings.Select(MapToPairingDTO).ToList();
+        }
+
+        var allPairings = await query.ToListAsync();
+        return allPairings.Select(MapToPairingDTO).ToList();
     }
 
     /// <inheritdoc />

--- a/Backend/VTA.Tests/IntegrationTests/ControllerTests/CategoriesControllerTests.cs
+++ b/Backend/VTA.Tests/IntegrationTests/ControllerTests/CategoriesControllerTests.cs
@@ -33,8 +33,9 @@ public class CategoriesControllerTests : IClassFixture<CustomApplicationFactory>
         var response = await _client.SendAsync(request);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        var categories = await response.Content.ReadFromJsonAsync<List<CategoryGetDTO>>();
-        Assert.NotNull(categories);
+        var page = await response.Content.ReadFromJsonAsync<PaginatedResponse<CategoryGetDTO>>();
+        Assert.NotNull(page);
+        Assert.NotNull(page.Items);
 
         await _utilities.DeleteUserAsync(signUpResult!.userId, token);
     }

--- a/improvementPlan.md
+++ b/improvementPlan.md
@@ -5,14 +5,16 @@
 > its KEY that you FIRST plan and then execute
 > ensure that each logically clustered improvement is its own feature branch
 
-## Status (7 Feb 2026)
+## Status (8 Feb 2026)
 
-| Phase | Status | Branch | Tests |
-|-------|--------|--------|-------|
-| Phase 1 — Stop the Bleeding | ✅ Merged to `dev-main` | `feature/phase1-stabilise` | 98/98 ✅ |
-| Phase 2 — Backend Service Layer | ✅ Merged to `dev-main` | `feature/phase2-service-layer` | 98/98 ✅ |
-| Phase 3 — God Class Splits | ✅ Completed | `feature/phase3-god-class-splits` | 25/25 + 98/98 + 13/13 ✅ |
-| Phase 4 — Reliability & Observability | � In progress | `feature/phase4-logging` | — |
+| Phase | Status | PR(s) | Tests |
+|-------|--------|-------|-------|
+| Phase 1 — Stop the Bleeding | ✅ Merged | PR #282 | 98/98 ✅ |
+| Phase 2 — Backend Service Layer | ✅ Merged | PR #284 | 98/98 ✅ |
+| Phase 3 — God Class Splits | ✅ Merged | PR #284 | 25/25 + 98/98 + 13/13 ✅ |
+| Phase 4.1–4.3 Logging | ✅ Merged | PR #285 | — |
+| Phase 4.4 Sync Retry | ✅ Merged | PR #286 | 13/13 ✅ |
+| Phase 4.5 Backend Pagination | ✅ Merged | PR #288 | 98/98 + 25/25 ✅ |
 | Phase 5 — Backlog | 📋 Planned | — | — |
 
 **Phase 3 progress:**
@@ -363,9 +365,9 @@ Add `logger.warning()`/`logger.severe()` calls inside all 28 empty `catch` block
 
 Create a `RetryHelper` utility with exponential backoff for HTTP calls. Apply in `sync_downloader.dart` and `sync_uploader.dart`. Wrap per-entity-type sync in SQLite batch transactions. Change `syncFromServer` return type from `bool` to a `SyncResult` with error details.
 
-### 4.5 Add backend pagination to list endpoints ⬜
+### 4.5 Add backend pagination to list endpoints ✅
 
-Add `skip`/`take` query params with sensible defaults (e.g., `take=50`) to admin user listings, artefact listing, board listing, and sync endpoints. Add `PaginatedResponse<T>` DTO with `items`, `totalCount`, `skip`, `take`. Backward-compatible — callers that don't pass params get the default page size.
+Added `PaginatedResponse<T>` DTO and `PaginationExtensions.ToPaginatedAsync()` extension method. Updated 11 list endpoints across 6 controllers (Admin, Users, Artefacts, Boards, Categories, Relation) with optional `skip`/`take` query params. Updated 3 service interfaces + implementations. Backward-compatible — existing callers without pagination params get default page size (50, max 200).
 
 ## Phase 5 — Backlog
 


### PR DESCRIPTION
Adds optional `skip`/`take` query parameters to all list endpoints, with a generic `PaginatedResponse<T>` wrapper.

## Changes

### New files
- **`DTOs/PaginationDTO.cs`** — `PaginatedResponse<T>` with `Items`, `TotalCount`, `Skip`, `Take`
- **`Extensions/PaginationExtensions.cs`** — `ToPaginatedAsync()` IQueryable extension (default 50, max 200)

### Updated controllers (11 endpoints across 6 controllers)
- **AdminController** — `GET caregivers`, `children`, `admins`, `pairings`
- **UsersController** — `GET users`
- **ArtefactsController** — `GET artefacts`
- **BoardsController** — `GET boards`, `GET boards/list`
- **CategoriesController** — `GET categories`
- **RelationController** — `GET pairings`, `GET caregiver/{id}`

### Updated services
- `IArtefactService` / `ArtefactService` — `GetArtefactsForUserAsync(skip, take)`
- `IBoardService` / `BoardService` — `GetBoardsForUserAsync(skip, take)`, `GetBoardListAsync(skip, take)`
- `IRelationService` / `RelationService` — `GetAllPairingsAsync(skip, take)`, `GetPairingsForCaregiverAsync(skip, take)`

### Backward-compatible
Callers that don't pass `skip`/`take` get the default page size (50). Existing tests updated to handle new response shape.

### Tests
- ✅ VTA.Tests: 98/98
- ✅ SyncService.Tests: 25/25