### PR TITLE
fix: parse paginated {items} envelope in artefact/category/user fetches (#290)

### DIFF
--- a/Frontend/vta_app/lib/src/models/artefact_model.dart
+++ b/Frontend/vta_app/lib/src/models/artefact_model.dart
@@ -173,7 +173,10 @@ class ArtifactModel {
         'Authorization': 'Bearer $token',
       });
       if (response != null && response.ok) {
-        var jsonResponse = json.decode(response.body) as List;
+        final decoded = json.decode(response.body);
+        var jsonResponse = (decoded is Map && decoded['items'] is List)
+            ? decoded['items'] as List
+            : decoded as List;
 
         _log.info(
             "Online ------------------------------------------------------- $jsonResponse");
@@ -428,7 +431,10 @@ class ArtifactModel {
         'Authorization': 'Bearer $token',
       });
       if (response != null && response.ok) {
-        var jsonResponse = json.decode(response.body) as List;
+        final decoded = json.decode(response.body);
+        var jsonResponse = (decoded is Map && decoded['items'] is List)
+            ? decoded['items'] as List
+            : decoded as List;
         var newMostUsedCategories = jsonResponse
             .map((jsonCategory) =>
                 Category.fromJson(jsonCategory as Map<String, dynamic>))

--- a/Frontend/vta_app/lib/src/utilities/data/data_repository.dart
+++ b/Frontend/vta_app/lib/src/utilities/data/data_repository.dart
@@ -85,7 +85,10 @@ class ArtifactRepository extends ApiDataRepository {
       var response =
           await apiProvider.fetchAsJson('Categories', headers: headers);
       if (responseOk(response)) {
-        var jsonResponse = json.decode(response!.body) as List;
+        final decoded = json.decode(response!.body);
+        var jsonResponse = (decoded is Map && decoded['items'] is List)
+            ? decoded['items'] as List
+            : decoded as List;
         var categories = jsonResponse
             .map((jsonCategory) =>
                 Category.fromJson(jsonCategory as Map<String, dynamic>))
@@ -217,7 +220,10 @@ class ArtifactRepository extends ApiDataRepository {
           headers: headers);
 
       if (responseOk(response)) {
-        var jsonResponse = json.decode(response!.body) as List;
+        final decoded = json.decode(response!.body);
+        var jsonResponse = (decoded is Map && decoded['items'] is List)
+            ? decoded['items'] as List
+            : decoded as List;
         var categories = jsonResponse
             .map((jsonCategory) =>
                 Category.fromJson(jsonCategory as Map<String, dynamic>))
@@ -278,7 +284,10 @@ class UserRepository extends ApiDataRepository {
       };
       var response = await apiProvider.fetchAsJson('Users', headers: headers);
       if (responseOk(response)) {
-        var jsonResponse = json.decode(response!.body) as List;
+        final decoded = json.decode(response!.body);
+        var jsonResponse = (decoded is Map && decoded['items'] is List)
+            ? decoded['items'] as List
+            : decoded as List;
         var users = jsonResponse
             .map((jsonUser) => User.fromJson(jsonUser as Map<String, dynamic>))
             .toList();
@@ -309,7 +318,10 @@ class UserRepository extends ApiDataRepository {
       _log.fine('Related contacts request: ${response?.request}');
 
       if (responseOk(response)) {
-        var jsonResponse = json.decode(response!.body) as List;
+        final decoded = json.decode(response!.body);
+        var jsonResponse = (decoded is Map && decoded['items'] is List)
+            ? decoded['items'] as List
+            : decoded as List;
         var users = jsonResponse
             .map((jsonUser) => User.fromJson(jsonUser as Map<String, dynamic>))
             .toList();


### PR DESCRIPTION
> 🤖 **AI-generated PR.** Written and verified by **Claude (Claude Code)** on behalf of @nbhansen. Please review before merging.

Fixes **#290**.

## Problem

`GET /api/Categories` and `GET /api/Users` return a **paginated envelope** — `{ "items": [...], "totalCount", "skip", "take" }` — but the Flutter app parsed these responses as a bare JSON array:

```dart
var jsonResponse = json.decode(response.body) as List; // body is a Map -> throws
```

This throws `TypeError: ... is not a subtype of type 'List<dynamic>'`, which propagates from `fetchAndUpdateCategories` (`artefact_model.dart:176`, rethrown) and surfaces on the board view as an error banner — the artefact **category palette never loads**. It reproduces with a brand-new user that has no categories/artefacts (the envelope is returned regardless of data).

## Fix

Tolerantly unwrap `items` when the response is a `Map`, while still accepting a bare list (so it works whether or not the backend is paginated), at all six affected fetch sites:

- `artefact_model.dart` — `fetchAndUpdateCategories`, `fetchAndUpdateMostUsedCategories`
- `data_repository.dart` — `fetchCategories`, `fetchMostUsedCategories`, `fetchAllUsers`, `fetchRelatedContacts`

## Verification

Built `flutter build web` and logged in as a fresh user and as a seeded user: the board view no longer throws, and the category/artefact palette loads correctly.

## Note

The Vue admin dashboard has the **same** root cause for its Users table (#291, `getAllUsers()` doesn't unwrap `items`); that is **not** included here.